### PR TITLE
Fix conversion from size_t to uint32_t.

### DIFF
--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -46,9 +46,9 @@ struct aws_event_stream_message {
     uint8_t owns_buffer;
 };
 
-#define AWS_EVENT_STREAM_PRELUDE_LENGTH (sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
+#define AWS_EVENT_STREAM_PRELUDE_LENGTH (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
 
-#define AWS_EVENT_STREAM_TRAILER_LENGTH (sizeof(uint32_t))
+#define AWS_EVENT_STREAM_TRAILER_LENGTH (uint32_t)(sizeof(uint32_t))
 
 enum aws_event_stream_header_value_type {
     AWS_EVENT_STREAM_HEADER_BOOL_TRUE = 0,


### PR DESCRIPTION
*Description of changes:*
Recent `Wconversion` will break the code because of failure to convert from `size_t` to `uint32_t`.
https://github.com/awslabs/aws-c-event-stream/blob/920c4f385bb5b6139f69b06233ebf84d1515a4cc/source/event_stream.c#L407

This PR will define constants as `uint32_t` to fix that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
