### PR TITLE
Add length member to event_stream_message

### DIFF
--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -43,6 +43,7 @@ struct aws_event_stream_message {
     struct aws_allocator *alloc;
     uint8_t *message_buffer;
     uint8_t owns_buffer;
+    size_t len;
 };
 
 #define AWS_EVENT_STREAM_PRELUDE_LENGTH (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))

--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -274,6 +274,7 @@ int aws_event_stream_message_init(
 
     message->alloc = alloc;
     message->message_buffer = aws_mem_acquire(message->alloc, total_length);
+    message->len = total_length;
 
     if (message->message_buffer) {
         message->owns_buffer = 1;


### PR DESCRIPTION
Needed when serializing the message bits to a network stream for
example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
