### PR TITLE
Switch /MT to /MD for dynamic lib and /MD to /MT for static lib on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 cmake_minimum_required (VERSION 3.1)
+option(STATIC_CRT "Windows specific option that to specify static/dynamic run-time library" OFF)
+
 project (aws-c-event-stream C)
 
 if (UNIX AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 cmake_minimum_required (VERSION 3.1)
-option(STATIC_CRT "Windows specific option that to specify static/dynamic run-time library" OFF)
-
 project (aws-c-event-stream C)
 
 if (UNIX AND NOT APPLE)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -12,13 +12,13 @@
 # permissions and limitations under the License.
 
 add_executable(aws-c-event-stream-pipe "event_stream_pipe.c")
-
+aws_set_common_properties(aws-c-event-stream-pipe)
 target_link_libraries(aws-c-event-stream-pipe ${CMAKE_PROJECT_NAME})
 set_target_properties(aws-c-event-stream-pipe PROPERTIES LINKER_LANGUAGE C)
 set_property(TARGET aws-c-event-stream-pipe PROPERTY C_STANDARD 99)
 
 add_executable(aws-c-event-stream-write-test-case "event_stream_write_test_case.c")
-
+aws_set_common_properties(aws-c-event-stream-write-test-case)
 target_link_libraries(aws-c-event-stream-write-test-case ${CMAKE_PROJECT_NAME})
 set_target_properties(aws-c-event-stream-write-test-case PROPERTIES LINKER_LANGUAGE C)
 set_property(TARGET aws-c-event-stream-write-test-case PROPERTY C_STANDARD 99)

--- a/bin/event_stream_pipe.c
+++ b/bin/event_stream_pipe.c
@@ -18,6 +18,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/**
+ * 4996 is to disable unsafe function fopen vs fopen_s
+ * 4706 is to disable assignment expression inside condition expression at line 133.
+ */
 #ifdef _MSC_VER
 #pragma warning (disable: 4996 4706)
 #endif

--- a/bin/event_stream_pipe.c
+++ b/bin/event_stream_pipe.c
@@ -18,6 +18,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef _MSC_VER
+#pragma warning (disable: 4996 4706)
+#endif
+
 static void s_on_payload_segment(
     struct aws_event_stream_streaming_decoder *decoder,
     struct aws_byte_buf *data,

--- a/bin/event_stream_write_test_case.c
+++ b/bin/event_stream_write_test_case.c
@@ -27,6 +27,10 @@
 #    define DELIM "/"
 #endif
 
+/**
+ * 4996 is to disable unsafe function sprintf vs sprintf_s
+ * 4310 is to disable type casting to smaller type at line 215, which is needed to avoid gcc overflow warning when casting int to int8_t
+ */
 #ifdef _MSC_VER
 #pragma warning (disable: 4996 4310)
 #endif

--- a/bin/event_stream_write_test_case.c
+++ b/bin/event_stream_write_test_case.c
@@ -28,7 +28,7 @@
 #endif
 
 #ifdef _MSC_VER
-#pragma warning (disable: 4996 4706)
+#pragma warning (disable: 4996 4310)
 #endif
 
 static void write_negative_test_case(

--- a/bin/event_stream_write_test_case.c
+++ b/bin/event_stream_write_test_case.c
@@ -27,6 +27,10 @@
 #    define DELIM "/"
 #endif
 
+#ifdef _MSC_VER
+#pragma warning (disable: 4996 4706)
+#endif
+
 static void write_negative_test_case(
     const char *root_dir,
     const char *test_name,
@@ -204,7 +208,7 @@ int main(void) {
     aws_event_stream_add_bool_header(&headers, bool_true, sizeof(bool_true) - 1, 1);
 
     static const char byte_hdr[] = "byte";
-    aws_event_stream_add_byte_header(&headers, byte_hdr, sizeof(byte_hdr) - 1, 0xcf);
+    aws_event_stream_add_byte_header(&headers, byte_hdr, sizeof(byte_hdr) - 1, (int8_t)0xcf);
 
     static const char byte_buf_hdr[] = "byte buf";
     static const char byte_buf[] = "I'm a little teapot!";


### PR DESCRIPTION
*Issue #, if available:*
When building static library, CPP SDK and aws-c-common will switch flag /MD to /MT, aws-checksums and aws-c-event-streams should do the same thing, otherwise there will be linking warning of incompatible MSVCRTD library.
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
