### PR TITLE
Use aws-c-event-stream as a git submodule of aws-crt-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include(AwsCFlags)
 include(AwsSharedLibSetup)
 include(AwsSanitizers)
 include(CheckCCompilerFlag)
+include(AwsFindPackage)
 
 if(NOT MSVC)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -70,25 +71,25 @@ file(GLOB EVENT_STREAM_SRC
     ${AWS_EVENT_STREAM_SRC}
 )
 
-add_library(${CMAKE_PROJECT_NAME} ${EVENT_STREAM_SRC})
-aws_set_common_properties(${CMAKE_PROJECT_NAME})
-aws_add_sanitizers(${CMAKE_PROJECT_NAME})
-aws_prepare_symbol_visibility_args(${CMAKE_PROJECT_NAME} "AWS_EVENT_STREAM")
+add_library(${PROJECT_NAME} ${EVENT_STREAM_SRC})
+aws_set_common_properties(${PROJECT_NAME})
+aws_add_sanitizers(${PROJECT_NAME})
+aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_EVENT_STREAM")
 
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES VERSION 1.0.0)
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES SOVERSION 0unstable)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 0unstable)
 
-find_package(aws-c-common REQUIRED)
-find_package(aws-checksums REQUIRED)
+aws_use_package(aws-c-common)
+aws_use_package(aws-checksums)
 
-target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC AWS::aws-c-common AWS::aws-checksums)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
 
-aws_prepare_shared_lib_exports(${CMAKE_PROJECT_NAME})
+aws_prepare_shared_lib_exports(${PROJECT_NAME})
 
 install(FILES ${AWS_EVENT_STREAM_HEADERS}
     DESTINATION "include/aws/event-stream"
@@ -100,17 +101,17 @@ else()
    set (TARGET_DIR "static")
 endif()
 
-install(EXPORT "${CMAKE_PROJECT_NAME}-targets"
-    DESTINATION "${LIBRARY_DIRECTORY}/${CMAKE_PROJECT_NAME}/cmake/${TARGET_DIR}/"
+install(EXPORT "${PROJECT_NAME}-targets"
+    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}/"
     NAMESPACE AWS::
     COMPONENT Development)
 
-configure_file("cmake/${CMAKE_PROJECT_NAME}-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
+configure_file("cmake/${PROJECT_NAME}-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     @ONLY)
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
-    DESTINATION "${LIBRARY_DIRECTORY}/${CMAKE_PROJECT_NAME}/cmake/"
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
     COMPONENT Development)
 
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -13,12 +13,12 @@
 
 add_executable(aws-c-event-stream-pipe "event_stream_pipe.c")
 aws_set_common_properties(aws-c-event-stream-pipe)
-target_link_libraries(aws-c-event-stream-pipe ${CMAKE_PROJECT_NAME})
+target_link_libraries(aws-c-event-stream-pipe ${PROJECT_NAME})
 set_target_properties(aws-c-event-stream-pipe PROPERTIES LINKER_LANGUAGE C)
 set_property(TARGET aws-c-event-stream-pipe PROPERTY C_STANDARD 99)
 
 add_executable(aws-c-event-stream-write-test-case "event_stream_write_test_case.c")
 aws_set_common_properties(aws-c-event-stream-write-test-case)
-target_link_libraries(aws-c-event-stream-write-test-case ${CMAKE_PROJECT_NAME})
+target_link_libraries(aws-c-event-stream-write-test-case ${PROJECT_NAME})
 set_target_properties(aws-c-event-stream-write-test-case PROPERTIES LINKER_LANGUAGE C)
 set_property(TARGET aws-c-event-stream-write-test-case PROPERTY C_STANDARD 99)

--- a/cmake/aws-c-event-stream-config.cmake
+++ b/cmake/aws-c-event-stream-config.cmake
@@ -3,8 +3,8 @@ find_dependency(aws-c-common)
 find_dependency(aws-checksums)
 
 if (BUILD_SHARED_LIBS)
-    include(${CMAKE_CURRENT_LIST_DIR}/shared/@CMAKE_PROJECT_NAME@-targets.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
 else()
-    include(${CMAKE_CURRENT_LIST_DIR}/static/@CMAKE_PROJECT_NAME@-targets.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ enable_testing()
 file(GLOB TEST_SRC "*.c")
 file(GLOB TESTS ${TEST_SRC})
 
-set(TEST_BINARY_NAME ${CMAKE_PROJECT_NAME}-tests)
+set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 
 add_test_case(test_incoming_no_op_valid)
 add_test_case(test_incoming_application_data_no_headers_valid)


### PR DESCRIPTION
*Issue*
If use aws-c-event-stream as a git submodule of aws-crt-cpp, `CMAKE_PROJECT_NAME` will be `aws-crt-cpp`, instead of `aws-c-event-stream`.

*Description of changes:*
1. Replace `CMAKE_PROJECT_NAME` with `PROJECT_NAME`
2. Use `aws_use_package()` to find dependencies: `aws-c-common` and `aws-checksums`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
