### PR TITLE
Only build tests and bin when BUILD_TESTING is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,10 +107,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
 
 include(CTest)
 enable_testing()
-add_subdirectory(tests)
+if (BUILD_TESTING)
+    add_subdirectory(tests)
 
-if(NOT MSVC)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    if(NOT MSVC)
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    endif()
+
+    add_subdirectory(bin)
 endif()
-
-add_subdirectory(bin)


### PR DESCRIPTION
When using aws-c-event-stream as a submodule to a CMake project tests and executables should be configurable.