### PR TITLE
Fix bug where client "forgets" it received CONNECT_ACK

### DIFF
--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -412,7 +412,7 @@ static void s_on_protocol_message_written_fn(
         (void *)message);
 
     if (message_args->message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
-        AWS_LOGF_DEBUG(
+        AWS_LOGF_TRACE(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
             "id=%p: connect message flushed to the wire.",
             (void *)message_args->connection);

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -414,9 +414,8 @@ static void s_on_protocol_message_written_fn(
     if (message_args->message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
         AWS_LOGF_DEBUG(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: connect message flushed to the wire, waiting on connect ack.",
+            "id=%p: connect message flushed to the wire.",
             (void *)message_args->connection);
-        aws_atomic_store_int(&message_args->connection->handshake_state, CONNECTION_HANDSHAKE_STATE_CONNECT_PROCESSED);
     }
 
     if (message_args->end_stream) {

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -534,7 +534,10 @@ static int s_send_protocol_message(
     }
 
     if (message_args->message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
-        AWS_LOGF_DEBUG(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: sending connect message", (void *)connection);
+        AWS_LOGF_DEBUG(
+            AWS_LS_EVENT_STREAM_RPC_CLIENT,
+            "id=%p: sending connect message, waiting on connect ack",
+            (void *)connection);
         aws_atomic_store_int(&connection->handshake_state, CONNECTION_HANDSHAKE_STATE_CONNECT_PROCESSED);
     }
 


### PR DESCRIPTION
## Client bug
Bug would manifest as a `AWS_ERROR_EVENT_STREAM_RPC_PROTOCOL_ERROR` if an `APPLICATION_MESSAGE` was sent immediately upon receiving a `CONNECT_ACK`

Turns out the client was setting `state=CONNECT_PROCESSED` in two places:
1) When writing the CONNECT message
2) When the CONNECT message's write-completion callback fired.

Fix is to ONLY set `state=CONNECT_PROCESSED` in place 1.

Bug would occur if the CONNECT_ACK was received before the CONNECT's write-complete callback fired. The state would go from CONNECT_ACK_PROCESSED back to CONNECT_PROCESSED.

This bug began manifesting when aws-c-io changed (PR# https://github.com/awslabs/aws-c-io/pull/353) so that the write-completion callback never fired synchronously. This made it possible to receive a CONNECT_ACK before the CONNECT's write-completion callback fired. The write-completion callback always worked this way on windows though, so it is still righteous to fix the bug in aws-c-event-stream, rather than make further changes to aws-c-io.

## Server bug

Server was only setting `state=CONNECT_ACK_PROCESSED` in one place, but it was setting it from the write-completion callback. Seems like a similar thing could happen:
1) server sends CONNECT_ACK
2) client receives CONNECT_ACK
3) client send APPLICATION_MESSAGE
4) server receives APPLICATION_MESSAGE. This causes error because state is not yet `CONNECT_ACK_PROCESSED`
5) CONNECT_ACK write-completion fires, we set `STATE=CONNECT_ACK_PROCESSED`, but too late connection is already shutting down in error

Fix is to set `state=CONNECT_ACK_PROCESSED` when writing the CONNECT_ACK message, not when the write completes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
