### PR TITLE
Fix for deprecated header API always failing

### DIFF
--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -216,8 +216,7 @@ size_t aws_event_stream_write_headers_to_buffer(const struct aws_array_list *hea
     AWS_FATAL_PRECONDITION(buffer);
 
     uint32_t min_buffer_len_assumption = aws_event_stream_compute_headers_required_buffer_len(headers);
-    struct aws_byte_buf safer_buf = aws_byte_buf_from_array(buffer, min_buffer_len_assumption);
-    safer_buf.len = 0;
+    struct aws_byte_buf safer_buf = aws_byte_buf_from_empty_array(buffer, min_buffer_len_assumption);
 
     if (aws_event_stream_write_headers_to_buffer_safe(headers, &safer_buf)) {
         return 0;

--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -217,6 +217,7 @@ size_t aws_event_stream_write_headers_to_buffer(const struct aws_array_list *hea
 
     uint32_t min_buffer_len_assumption = aws_event_stream_compute_headers_required_buffer_len(headers);
     struct aws_byte_buf safer_buf = aws_byte_buf_from_array(buffer, min_buffer_len_assumption);
+    safer_buf.len = 0;
 
     if (aws_event_stream_write_headers_to_buffer_safe(headers, &safer_buf)) {
         return 0;


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
