### PR TITLE
Remove raising an error if the stream_id is not sequentially increasing

### DIFF
--- a/source/event_stream_rpc_server.c
+++ b/source/event_stream_rpc_server.c
@@ -912,13 +912,6 @@ static void s_route_message_by_type(
                     AWS_LS_EVENT_STREAM_RPC_SERVER,
                     "id=%p: stream_id is invalid because it's not sequentially increasing",
                     (void *)connection);
-
-                aws_raise_error(AWS_ERROR_EVENT_STREAM_RPC_PROTOCOL_ERROR);
-                s_send_connection_level_error(
-                    connection,
-                    AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PROTOCOL_ERROR,
-                    0,
-                    &s_invalid_new_client_stream_id_error);
                 return;
             }
 

--- a/tests/event_stream_rpc_server_connection_test.c
+++ b/tests/event_stream_rpc_server_connection_test.c
@@ -1375,25 +1375,25 @@ static int s_test_event_stream_rpc_server_connection_stream_id_ahead(struct aws_
     ASSERT_SUCCESS(aws_event_stream_message_from_buffer_copy(&written_message, allocator, &io_message->message_data));
     ASSERT_SUCCESS(aws_event_stream_message_headers(&written_message, &headers_list));
 
-    bool message_type_found = false;
+    // bool message_type_found = false;
 
-    for (size_t i = 0; i < aws_array_list_length(&headers_list); ++i) {
-        struct aws_event_stream_header_value_pair *header = NULL;
-        aws_array_list_get_at_ptr(&headers_list, (void **)&header, i);
+    // for (size_t i = 0; i < aws_array_list_length(&headers_list); ++i) {
+    //     struct aws_event_stream_header_value_pair *header = NULL;
+    //     aws_array_list_get_at_ptr(&headers_list, (void **)&header, i);
 
-        struct aws_byte_cursor header_name = aws_byte_cursor_from_array(header->header_name, header->header_name_len);
+    //     struct aws_byte_cursor header_name = aws_byte_cursor_from_array(header->header_name, header->header_name_len);
 
-        if (aws_byte_cursor_eq(&aws_event_stream_rpc_message_type_name, &header_name)) {
-            message_type_found = true;
-            ASSERT_INT_EQUALS(
-                AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PROTOCOL_ERROR, aws_event_stream_header_value_as_int32(header));
-        }
-    }
+    //     if (aws_byte_cursor_eq(&aws_event_stream_rpc_message_type_name, &header_name)) {
+    //         message_type_found = true;
+    //         ASSERT_INT_EQUALS(
+    //             AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PROTOCOL_ERROR, aws_event_stream_header_value_as_int32(header));
+    //     }
+    // }
 
     aws_event_stream_headers_list_cleanup(&headers_list);
     aws_event_stream_message_clean_up(&written_message);
 
-    ASSERT_TRUE(message_type_found);
+    // ASSERT_TRUE(message_type_found);
 
     testing_channel_drain_queued_tasks(&test_data->testing_channel);
 


### PR DESCRIPTION
*Description of changes:*

Fixes an issue where a race condition when unsubscribing and publishing in Greengrass can lead to the unsubscribe arriving before the publish, causing the packets to be out of order and lead to a total disconnect. This PR will make it just log the error but otherwise continue.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
