### PR TITLE
Use the serialized task scheduling method for submitting message tasks

### DIFF
--- a/source/event_stream_channel_handler.c
+++ b/source/event_stream_channel_handler.c
@@ -358,7 +358,7 @@ int aws_event_stream_channel_handler_write_message(
         AWS_LS_EVENT_STREAM_CHANNEL_HANDLER, "id=%p: Scheduling message write task", (void *)channel_handler);
     aws_channel_task_init(
         &write_data->task, s_write_handler_message, write_data, "aws_event_stream_channel_handler_write_message");
-    aws_channel_schedule_task_now(handler->handler.slot->channel, &write_data->task);
+    aws_channel_schedule_task_now_serialized(handler->handler.slot->channel, &write_data->task);
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
Fixes an issue where event stream ids could be sent in non-ascending order due to the the way the default channel task scheduling can change behavior based on whether or not it is invoked from the seated event loop thread.  This was considered a much easier and less risky change than doing a large refactoring to how event stream messages are submitted and serialized.

The problem came about when continuations were activated from both an external thread and the event loop thread (for example, on a stream callback).  It was possible that the external thread would allocate an id first and submit its task to flush the stream creation message, but then that task would get "leap-frogged" by an activation submitted on the event stream thread with a higher id.  By using an API that always uses the cross-thread task queue, this order inversion is avoided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
