### PR TITLE
Add AppVerifier to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,17 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
+  windows-app-verifier:
+    runs-on: windows-2022 # latest
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} run_tests=false --cmake-extra=-DBUILD_TESTING=ON
+    - name: Run and check AppVerifier
+      run: |
+        python .\aws-c-event-stream\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-event-stream\build\aws-c-event-stream
+
   osx:
     runs-on: macos-11 # latest
     steps:


### PR DESCRIPTION
*Description of changes:*

Adds AppVerifier to run alongside tests for `aws-c-event-stream` to ensure proper Win32 API usage.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
