### PR TITLE
Potential stream race fix

### DIFF
--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -322,8 +322,8 @@ error:
 
 void aws_event_stream_rpc_client_connection_acquire(const struct aws_event_stream_rpc_client_connection *connection) {
     AWS_PRECONDITION(connection);
-    size_t current_count = aws_atomic_fetch_add_explicit(
-        &((struct aws_event_stream_rpc_client_connection *)connection)->ref_count, 1, aws_memory_order_seq_cst);
+    size_t current_count =
+        aws_atomic_fetch_add(&((struct aws_event_stream_rpc_client_connection *)connection)->ref_count, 1);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: connection acquired, new ref count is %zu.",
@@ -345,7 +345,7 @@ void aws_event_stream_rpc_client_connection_release(const struct aws_event_strea
 
     struct aws_event_stream_rpc_client_connection *connection_mut =
         (struct aws_event_stream_rpc_client_connection *)connection;
-    size_t ref_count = aws_atomic_fetch_sub_explicit(&connection_mut->ref_count, 1, aws_memory_order_seq_cst);
+    size_t ref_count = aws_atomic_fetch_sub(&connection_mut->ref_count, 1);
 
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
@@ -931,10 +931,8 @@ void *aws_event_stream_rpc_client_continuation_get_user_data(
 
 void aws_event_stream_rpc_client_continuation_acquire(
     const struct aws_event_stream_rpc_client_continuation_token *continuation) {
-    size_t current_count = aws_atomic_fetch_add_explicit(
-        &((struct aws_event_stream_rpc_client_continuation_token *)continuation)->ref_count,
-        1u,
-        aws_memory_order_seq_cst);
+    size_t current_count =
+        aws_atomic_fetch_add(&((struct aws_event_stream_rpc_client_continuation_token *)continuation)->ref_count, 1u);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: continuation acquired, new ref count is %zu.",
@@ -950,22 +948,13 @@ void aws_event_stream_rpc_client_continuation_release(
 
     struct aws_event_stream_rpc_client_continuation_token *continuation_mut =
         (struct aws_event_stream_rpc_client_continuation_token *)continuation;
-    size_t ref_count = aws_atomic_fetch_sub_explicit(&continuation_mut->ref_count, 1, aws_memory_order_seq_cst);
+    size_t ref_count = aws_atomic_fetch_sub(&continuation_mut->ref_count, 1);
 
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: continuation released, new ref count is %zu.",
         (void *)continuation,
         ref_count - 1);
-
-    if (ref_count <= 0) {
-        bool done = false;
-        while (!done) {
-            ;
-        }
-
-        return;
-    }
 
     AWS_FATAL_ASSERT(ref_count != 0 && "Continuation ref count has gone negative");
 

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -956,12 +956,21 @@ void aws_event_stream_rpc_client_continuation_release(
         (void *)continuation,
         ref_count - 1);
 
+    if (ref_count <= 0) {
+        bool done = false;
+        while (!done) {
+            ;
+        }
+
+        return;
+    }
+
     AWS_FATAL_ASSERT(ref_count != 0 && "Continuation ref count has gone negative");
 
     if (ref_count == 1) {
-        struct aws_allocator *allocator = continuation_mut->connection->allocator;
+        //struct aws_allocator *allocator = continuation_mut->connection->allocator;
         aws_event_stream_rpc_client_connection_release(continuation_mut->connection);
-        aws_mem_release(allocator, continuation_mut);
+        // aws_mem_release(allocator, continuation_mut);
     }
 }
 

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -323,7 +323,7 @@ error:
 void aws_event_stream_rpc_client_connection_acquire(const struct aws_event_stream_rpc_client_connection *connection) {
     AWS_PRECONDITION(connection);
     size_t current_count = aws_atomic_fetch_add_explicit(
-        &((struct aws_event_stream_rpc_client_connection *)connection)->ref_count, 1, aws_memory_order_relaxed);
+        &((struct aws_event_stream_rpc_client_connection *)connection)->ref_count, 1, aws_memory_order_seq_cst);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: connection acquired, new ref count is %zu.",
@@ -934,7 +934,7 @@ void aws_event_stream_rpc_client_continuation_acquire(
     size_t current_count = aws_atomic_fetch_add_explicit(
         &((struct aws_event_stream_rpc_client_continuation_token *)continuation)->ref_count,
         1u,
-        aws_memory_order_relaxed);
+        aws_memory_order_seq_cst);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: continuation acquired, new ref count is %zu.",

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -768,10 +768,12 @@ static void s_route_message_by_type(
             return;
         }
 
-        aws_mutex_unlock(&connection->stream_lock);
-
         continuation = continuation_element->value;
         aws_event_stream_rpc_client_continuation_acquire(continuation);
+
+        aws_mutex_unlock(&connection->stream_lock);
+
+        AWS_FATAL_ASSERT(continuation != NULL);
         continuation->continuation_fn(continuation, &message_args, continuation->user_data);
         aws_event_stream_rpc_client_continuation_release(continuation);
 

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -970,9 +970,9 @@ void aws_event_stream_rpc_client_continuation_release(
     AWS_FATAL_ASSERT(ref_count != 0 && "Continuation ref count has gone negative");
 
     if (ref_count == 1) {
-        //struct aws_allocator *allocator = continuation_mut->connection->allocator;
+        struct aws_allocator *allocator = continuation_mut->connection->allocator;
         aws_event_stream_rpc_client_connection_release(continuation_mut->connection);
-        // aws_mem_release(allocator, continuation_mut);
+        aws_mem_release(allocator, continuation_mut);
     }
 }
 

--- a/source/event_stream_rpc_server.c
+++ b/source/event_stream_rpc_server.c
@@ -227,7 +227,7 @@ struct aws_event_stream_rpc_server_connection *aws_event_stream_rpc_server_conne
 }
 
 void aws_event_stream_rpc_server_connection_acquire(struct aws_event_stream_rpc_server_connection *connection) {
-    size_t current_count = aws_atomic_fetch_add_explicit(&connection->ref_count, 1, aws_memory_order_relaxed);
+    size_t current_count = aws_atomic_fetch_add(&connection->ref_count, 1);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_SERVER,
         "id=%p: connection acquired, new ref count is %zu.",
@@ -240,7 +240,7 @@ void aws_event_stream_rpc_server_connection_release(struct aws_event_stream_rpc_
         return;
     }
 
-    size_t value = aws_atomic_fetch_sub_explicit(&connection->ref_count, 1, aws_memory_order_seq_cst);
+    size_t value = aws_atomic_fetch_sub(&connection->ref_count, 1);
 
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_SERVER,
@@ -447,7 +447,7 @@ uint16_t aws_event_stream_rpc_server_listener_get_bound_port(
 }
 
 void aws_event_stream_rpc_server_listener_acquire(struct aws_event_stream_rpc_server_listener *server) {
-    size_t current_count = aws_atomic_fetch_add_explicit(&server->ref_count, 1, aws_memory_order_relaxed);
+    size_t current_count = aws_atomic_fetch_add(&server->ref_count, 1);
 
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_SERVER,
@@ -469,7 +469,7 @@ void aws_event_stream_rpc_server_listener_release(struct aws_event_stream_rpc_se
         return;
     }
 
-    size_t ref_count = aws_atomic_fetch_sub_explicit(&server->ref_count, 1, aws_memory_order_seq_cst);
+    size_t ref_count = aws_atomic_fetch_sub(&server->ref_count, 1);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_SERVER, "id=%p: server released, new ref count is %zu.", (void *)server, ref_count - 1);
 
@@ -753,7 +753,7 @@ bool aws_event_stream_rpc_server_connection_is_open(struct aws_event_stream_rpc_
 
 void aws_event_stream_rpc_server_continuation_acquire(
     struct aws_event_stream_rpc_server_continuation_token *continuation) {
-    size_t current_count = aws_atomic_fetch_add_explicit(&continuation->ref_count, 1, aws_memory_order_relaxed);
+    size_t current_count = aws_atomic_fetch_add(&continuation->ref_count, 1);
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_SERVER,
         "id=%p: continuation acquired, new ref count is %zu.",
@@ -763,7 +763,7 @@ void aws_event_stream_rpc_server_continuation_acquire(
 
 void aws_event_stream_rpc_server_continuation_release(
     struct aws_event_stream_rpc_server_continuation_token *continuation) {
-    size_t value = aws_atomic_fetch_sub_explicit(&continuation->ref_count, 1, aws_memory_order_seq_cst);
+    size_t value = aws_atomic_fetch_sub(&continuation->ref_count, 1);
 
     AWS_LOGF_TRACE(
         AWS_LS_EVENT_STREAM_RPC_SERVER,

--- a/tests/event_stream_rpc_server_connection_test.c
+++ b/tests/event_stream_rpc_server_connection_test.c
@@ -160,9 +160,6 @@ static int s_fixture_setup_shared(
         };
 
         test_data->listener = aws_event_stream_rpc_server_new_listener(allocator, &listener_options);
-        if (!test_data->listener) {
-            ASSERT_INT_EQUALS(AWS_IO_SOCKET_ADDRESS_IN_USE, aws_last_error());
-        }
     }
 
     test_data->allocator = allocator;


### PR DESCRIPTION
* Fix a violation of the hash table lock invariant in rpc client (accessing internal hash table structure without the lock held)
* Move ref counting to always be sequentially consistent.  No one that maintains this code has the experience or expertise to justify using any looser ordering constraint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
