### PR TITLE
Fix continuation race condition and windows test failures

### DIFF
--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -768,10 +768,12 @@ static void s_route_message_by_type(
             return;
         }
 
+        continuation = continuation_element->value;
+        AWS_FATAL_ASSERT(continuation != NULL);
+        aws_event_stream_rpc_client_continuation_acquire(continuation);
+
         aws_mutex_unlock(&connection->stream_lock);
 
-        continuation = continuation_element->value;
-        aws_event_stream_rpc_client_continuation_acquire(continuation);
         continuation->continuation_fn(continuation, &message_args, continuation->user_data);
         aws_event_stream_rpc_client_continuation_release(continuation);
 

--- a/tests/event_stream_rpc_client_connection_test.c
+++ b/tests/event_stream_rpc_client_connection_test.c
@@ -322,7 +322,8 @@ static int s_fixture_setup(struct aws_allocator *allocator, void *ctx) {
 
         test_data->listener = aws_event_stream_rpc_server_new_listener(allocator, &listener_options);
         if (!test_data->listener) {
-            ASSERT_INT_EQUALS(AWS_IO_SOCKET_ADDRESS_IN_USE, aws_last_error());
+            int error_code = aws_last_error();
+            ASSERT_TRUE(error_code == AWS_IO_SOCKET_ADDRESS_IN_USE || error_code == AWS_ERROR_NO_PERMISSION);
         }
     }
 

--- a/tests/event_stream_rpc_server_connection_test.c
+++ b/tests/event_stream_rpc_server_connection_test.c
@@ -161,7 +161,8 @@ static int s_fixture_setup_shared(
 
         test_data->listener = aws_event_stream_rpc_server_new_listener(allocator, &listener_options);
         if (!test_data->listener) {
-            ASSERT_INT_EQUALS(AWS_IO_SOCKET_ADDRESS_IN_USE, aws_last_error());
+            int error_code = aws_last_error();
+            ASSERT_TRUE(error_code == AWS_IO_SOCKET_ADDRESS_IN_USE || error_code == AWS_ERROR_NO_PERMISSION);
         }
     }
 


### PR DESCRIPTION
* Hash elements are invalidated/mutated by add/remove.  If you're protecting your table with a lock, you must pull out your value from the element before releasing it.
* Some windows tests were flaky because Windows was giving a different error code on some port collisions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
