### PR TITLE
Add onComplete callback for streaming decoder

### DIFF
--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -173,7 +173,7 @@ struct aws_event_stream_streaming_decoder {
 struct aws_event_stream_streaming_decoder_options {
     /**
      * (Required)
-     * Invoked repeatedly times as payload segment are received.
+     * Invoked repeatedly as payload segment are received.
      * See `aws_event_stream_process_on_payload_segment_fn`.
      */
     aws_event_stream_process_on_payload_segment_fn *on_payload_segment;

--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -198,7 +198,7 @@ struct aws_event_stream_streaming_decoder_options {
     /**
      * (Required)
      * Invoked when an error is encountered. The decoder is not in a good state for usage after this callback.
-     * See `aws_event_stream_header_received_fn`.
+     * See `aws_event_stream_on_error_fn`.
      */
     aws_event_stream_on_error_fn *on_error;
     /**

--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -133,6 +133,15 @@ typedef void(aws_event_stream_header_received_fn)(
     void *user_data);
 
 /**
+ * Called by aws_aws_event_stream_streaming_decoder when a message decoding is complete
+ * and crc is verified.
+ */
+typedef void(aws_event_stream_on_complete_fn)(
+    struct aws_event_stream_streaming_decoder *decoder,
+    uint32_t running_crc,
+    void *user_data);
+
+/**
  * Called by aws_aws_event_stream_streaming_decoder when an error is encountered. The decoder is not in a good state for
  * usage after this callback.
  */
@@ -156,10 +165,19 @@ struct aws_event_stream_streaming_decoder {
     aws_event_stream_process_on_payload_segment_fn *on_payload;
     aws_event_stream_prelude_received_fn *on_prelude;
     aws_event_stream_header_received_fn *on_header;
+    aws_event_stream_on_complete_fn *on_complete;
     aws_event_stream_on_error_fn *on_error;
     void *user_context;
 };
 
+struct aws_event_stream_streaming_decoder_options {
+    aws_event_stream_process_on_payload_segment_fn *on_payload_segment;
+    aws_event_stream_prelude_received_fn *on_prelude;
+    aws_event_stream_header_received_fn *on_header;
+    aws_event_stream_on_complete_fn *on_complete;
+    aws_event_stream_on_error_fn *on_error;
+    void *user_data;
+};
 AWS_EXTERN_C_BEGIN
 
 /**
@@ -278,7 +296,19 @@ AWS_EVENT_STREAM_API int aws_event_stream_read_headers_from_buffer(
     struct aws_array_list *headers,
     const uint8_t *buffer,
     size_t headers_len);
+
 /**
+ * Initialize a streaming decoder for messages with callbacks for usage
+ * and an optional user context pointer.
+ */
+AWS_EVENT_STREAM_API
+void aws_event_stream_streaming_decoder_init_from_options(
+    struct aws_event_stream_streaming_decoder *decoder,
+    struct aws_allocator *allocator,
+    const struct aws_event_stream_streaming_decoder_options *options);
+
+/**
+ * Deprecated. Use aws_event_stream_streaming_decoder_init_from_options instead.
  * Initialize a streaming decoder for messages with callbacks for usage and an optional user context pointer.
  */
 AWS_EVENT_STREAM_API void aws_event_stream_streaming_decoder_init(

--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -171,11 +171,40 @@ struct aws_event_stream_streaming_decoder {
 };
 
 struct aws_event_stream_streaming_decoder_options {
+    /**
+     * (Required)
+     * Invoked repeatedly times as payload segment are received.
+     * See `aws_event_stream_process_on_payload_segment_fn`.
+     */
     aws_event_stream_process_on_payload_segment_fn *on_payload_segment;
+    /**
+     * (Required)
+     * Invoked when when a new message has arrived. The prelude will contain metadata about the message.
+     * See `aws_event_stream_prelude_received_fn`.
+     */
     aws_event_stream_prelude_received_fn *on_prelude;
+    /**
+     * (Required)
+     * Invoked repeatedly as headers are received.
+     * See `aws_event_stream_header_received_fn`.
+     */
     aws_event_stream_header_received_fn *on_header;
+    /**
+     * (Optional)
+     * Invoked if a message is decoded successfully.
+     * See `aws_event_stream_on_complete_fn`.
+     */
     aws_event_stream_on_complete_fn *on_complete;
+    /**
+     * (Required)
+     * Invoked when an error is encountered. The decoder is not in a good state for usage after this callback.
+     * See `aws_event_stream_header_received_fn`.
+     */
     aws_event_stream_on_error_fn *on_error;
+    /**
+     * (Optional)
+     * user_data passed to callbacks.
+     */
     void *user_data;
 };
 AWS_EXTERN_C_BEGIN

--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -138,7 +138,7 @@ typedef void(aws_event_stream_header_received_fn)(
  */
 typedef void(aws_event_stream_on_complete_fn)(
     struct aws_event_stream_streaming_decoder *decoder,
-    uint32_t running_crc,
+    uint32_t message_crc,
     void *user_data);
 
 /**

--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -1464,7 +1464,6 @@ void aws_event_stream_streaming_decoder_init_from_options(
     AWS_ASSERT(options->on_payload_segment);
     AWS_ASSERT(options->on_prelude);
     AWS_ASSERT(options->on_prelude);
-    AWS_ASSERT(options->on_complete);
 
     s_reset_state(decoder);
     decoder->alloc = allocator;

--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -1484,13 +1484,12 @@ void aws_event_stream_streaming_decoder_init(
     aws_event_stream_on_error_fn *on_error,
     void *user_data) {
 
-    s_reset_state(decoder);
-    decoder->alloc = alloc;
-    decoder->on_error = on_error;
-    decoder->on_header = on_header;
-    decoder->on_payload = on_payload_segment;
-    decoder->on_prelude = on_prelude;
-    decoder->user_context = user_data;
+    struct aws_event_stream_streaming_decoder_options decoder_options = {.on_payload_segment = on_payload_segment,
+                                                                         .on_prelude = on_prelude,
+                                                                         .on_header = on_header,
+                                                                         .on_error = on_error,
+                                                                         .user_data = user_data};
+    aws_event_stream_streaming_decoder_init_from_options(decoder, alloc, &decoder_options);
 }
 
 void aws_event_stream_streaming_decoder_clean_up(struct aws_event_stream_streaming_decoder *decoder) {

--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -1293,6 +1293,9 @@ static int s_read_trailer_state(
         uint32_t message_crc = aws_read_u32(decoder->working_buffer);
 
         if (message_crc == decoder->running_crc) {
+            if (decoder->on_complete) {
+                decoder->on_complete(decoder, message_crc, decoder->user_context);
+            }
             s_reset_state(decoder);
         } else {
             char error_message[70];
@@ -1449,6 +1452,30 @@ static void s_reset_state(struct aws_event_stream_streaming_decoder *decoder) {
     decoder->state = s_start_state;
 }
 
+void aws_event_stream_streaming_decoder_init_from_options(
+    struct aws_event_stream_streaming_decoder *decoder,
+    struct aws_allocator *allocator,
+    const struct aws_event_stream_streaming_decoder_options *options) {
+    AWS_ASSERT(decoder);
+    AWS_ASSERT(allocator);
+    AWS_ASSERT(options);
+    AWS_ASSERT(options->on_error);
+    AWS_ASSERT(options->on_header);
+    AWS_ASSERT(options->on_payload_segment);
+    AWS_ASSERT(options->on_prelude);
+    AWS_ASSERT(options->on_prelude);
+    AWS_ASSERT(options->on_complete);
+
+    s_reset_state(decoder);
+    decoder->alloc = allocator;
+    decoder->on_error = options->on_error;
+    decoder->on_header = options->on_header;
+    decoder->on_payload = options->on_payload_segment;
+    decoder->on_prelude = options->on_prelude;
+    decoder->on_complete = options->on_complete;
+    decoder->user_context = options->user_data;
+}
+
 void aws_event_stream_streaming_decoder_init(
     struct aws_event_stream_streaming_decoder *decoder,
     struct aws_allocator *alloc,
@@ -1474,6 +1501,7 @@ void aws_event_stream_streaming_decoder_clean_up(struct aws_event_stream_streami
     decoder->on_payload = 0;
     decoder->on_prelude = 0;
     decoder->user_context = 0;
+    decoder->on_complete = 0;
 }
 
 /* Simply sends the data to the state machine until all has been processed or an error is returned. */

--- a/tests/message_streaming_decoder_test.c
+++ b/tests/message_streaming_decoder_test.c
@@ -66,10 +66,10 @@ static void s_decoder_test_header_received(
 
 static void s_decoder_test_on_complete(
     struct aws_event_stream_streaming_decoder *decoder,
-    uint32_t running_crc,
+    uint32_t message_crc,
     void *user_data) {
     (void)decoder;
-    (void)running_crc;
+    (void)message_crc;
     struct test_decoder_data *decoder_data = (struct test_decoder_data *)user_data;
     decoder_data->on_complete_called = true;
 }


### PR DESCRIPTION
*Description of changes:*
- Adds a new onComplete callback to indicate a message is decoded successfully. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
