### PR TITLE
Explicit Private for target_link_libraries

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -3,12 +3,12 @@
 
 add_executable(aws-c-event-stream-pipe "event_stream_pipe.c")
 aws_set_common_properties(aws-c-event-stream-pipe)
-target_link_libraries(aws-c-event-stream-pipe ${PROJECT_NAME})
+target_link_libraries(aws-c-event-stream-pipe PRIVATE ${PROJECT_NAME})
 set_target_properties(aws-c-event-stream-pipe PROPERTIES LINKER_LANGUAGE C)
 set_property(TARGET aws-c-event-stream-pipe PROPERTY C_STANDARD 99)
 
 add_executable(aws-c-event-stream-write-test-case "event_stream_write_test_case.c")
 aws_set_common_properties(aws-c-event-stream-write-test-case)
-target_link_libraries(aws-c-event-stream-write-test-case ${PROJECT_NAME})
+target_link_libraries(aws-c-event-stream-write-test-case PRIVATE ${PROJECT_NAME})
 set_target_properties(aws-c-event-stream-write-test-case PROPERTIES LINKER_LANGUAGE C)
 set_property(TARGET aws-c-event-stream-write-test-case PROPERTY C_STANDARD 99)


### PR DESCRIPTION
*Description of changes:*
- The `target_link_libraries` should be either all-keyworded or non-keyworded. For non-keyworded configurations, there is no default, and it can be either PUBLIC or PRIVATE, depending on various configurations. So, explicitly make it private.

Source: https://cmake.org/pipermail/cmake/2016-May/063400.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
