### PR TITLE
Change `port` from uint16_t to uint32_t, to support VSOCK

### DIFF
--- a/include/aws/event-stream/event_stream_rpc_client.h
+++ b/include/aws/event-stream/event_stream_rpc_client.h
@@ -84,7 +84,7 @@ struct aws_event_stream_rpc_client_connection_options {
     /** host name to use for the connection. This depends on your socket type. */
     const char *host_name;
     /** port to use for your connection, assuming for the appropriate socket type. */
-    uint16_t port;
+    uint32_t port;
     /** socket options for establishing the connection to the RPC server. */
     const struct aws_socket_options *socket_options;
     /** optional: tls options for using when establishing your connection. */

--- a/include/aws/event-stream/event_stream_rpc_server.h
+++ b/include/aws/event-stream/event_stream_rpc_server.h
@@ -110,7 +110,7 @@ struct aws_event_stream_rpc_server_listener_options {
     /** host name to use for the listener. This depends on your socket type. */
     const char *host_name;
     /** port to use for your listener, assuming for the appropriate socket type. */
-    uint16_t port;
+    uint32_t port;
     const struct aws_socket_options *socket_options;
     /** optional: tls options for using when setting up your server. */
     const struct aws_tls_connection_options *tls_options;
@@ -140,7 +140,7 @@ AWS_EVENT_STREAM_API void aws_event_stream_rpc_server_listener_release(
  * Get the local port which the listener's socket is bound to.
  */
 AWS_EVENT_STREAM_API
-uint16_t aws_event_stream_rpc_server_listener_get_bound_port(
+uint32_t aws_event_stream_rpc_server_listener_get_bound_port(
     const struct aws_event_stream_rpc_server_listener *listener);
 
 /**

--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -1034,7 +1034,8 @@ int aws_event_stream_add_bytebuf_header(
         .header_name_len = name_len,
         .header_value_len = value_len,
         .value_owned = copy,
-        .header_value_type = AWS_EVENT_STREAM_HEADER_BYTE_BUF};
+        .header_value_type = AWS_EVENT_STREAM_HEADER_BYTE_BUF,
+    };
 
     return s_add_variable_len_header(headers, &header, name, name_len, value, value_len, copy);
 }
@@ -1607,7 +1608,8 @@ void aws_event_stream_streaming_decoder_init(
         .on_prelude = on_prelude,
         .on_header = on_header,
         .on_error = on_error,
-        .user_data = user_data};
+        .user_data = user_data,
+    };
     aws_event_stream_streaming_decoder_init_from_options(decoder, alloc, &decoder_options);
 }
 

--- a/source/event_stream_rpc_server.c
+++ b/source/event_stream_rpc_server.c
@@ -436,7 +436,7 @@ error:
     return NULL;
 }
 
-uint16_t aws_event_stream_rpc_server_listener_get_bound_port(
+uint32_t aws_event_stream_rpc_server_listener_get_bound_port(
     const struct aws_event_stream_rpc_server_listener *server) {
 
     struct aws_socket_endpoint address;

--- a/tests/event_stream_rpc_server_connection_test.c
+++ b/tests/event_stream_rpc_server_connection_test.c
@@ -251,7 +251,7 @@ static int s_fixture_setup_port0(struct aws_allocator *allocator, void *ctx) {
     test_data->listener = aws_event_stream_rpc_server_new_listener(allocator, &listener_options);
     ASSERT_NOT_NULL(test_data->listener);
 
-    uint16_t actual_port = aws_event_stream_rpc_server_listener_get_bound_port(test_data->listener);
+    uint32_t actual_port = aws_event_stream_rpc_server_listener_get_bound_port(test_data->listener);
     ASSERT_TRUE(actual_port > 0);
 
     test_data->allocator = allocator;


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-c-io/issues/576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
