### PR TITLE
Fix -Wuseless-cast compiler warning for public headers

### DIFF
--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -65,9 +65,13 @@ struct aws_event_stream_message {
     struct aws_byte_buf message_buffer;
 };
 
-#define AWS_EVENT_STREAM_PRELUDE_LENGTH (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
-
-#define AWS_EVENT_STREAM_TRAILER_LENGTH (uint32_t)(sizeof(uint32_t))
+#if SIZE_MAX == UINT32_MAX
+#    define AWS_EVENT_STREAM_PRELUDE_LENGTH (sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
+#    define AWS_EVENT_STREAM_TRAILER_LENGTH (sizeof(uint32_t))
+#else /* cast to uint32_t */
+#    define AWS_EVENT_STREAM_PRELUDE_LENGTH (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
+#    define AWS_EVENT_STREAM_TRAILER_LENGTH (uint32_t)(sizeof(uint32_t))
+#endif
 
 enum aws_event_stream_header_value_type {
     AWS_EVENT_STREAM_HEADER_BOOL_TRUE = 0,

--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -65,13 +65,11 @@ struct aws_event_stream_message {
     struct aws_byte_buf message_buffer;
 };
 
-#if SIZE_MAX == UINT32_MAX
-#    define AWS_EVENT_STREAM_PRELUDE_LENGTH (sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
-#    define AWS_EVENT_STREAM_TRAILER_LENGTH (sizeof(uint32_t))
-#else /* cast to uint32_t */
-#    define AWS_EVENT_STREAM_PRELUDE_LENGTH (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t))
-#    define AWS_EVENT_STREAM_TRAILER_LENGTH (uint32_t)(sizeof(uint32_t))
-#endif
+/* Prelude (12-bytes) = Total Byte Length (4-bytes) + Headers Byte Length (4-bytes) + Prelude CRC (4-bytes) */
+#define AWS_EVENT_STREAM_PRELUDE_LENGTH (uint32_t)(12)
+
+/* Trailer (4-bytes) = Message CRC (4-bytes) */
+#define AWS_EVENT_STREAM_TRAILER_LENGTH (uint32_t)(4)
 
 enum aws_event_stream_header_value_type {
     AWS_EVENT_STREAM_HEADER_BOOL_TRUE = 0,


### PR DESCRIPTION
**Issue #:**
https://github.com/awslabs/aws-c-common/issues/973

**Research:**
6 years ago, PR https://github.com/awslabs/aws-c-event-stream/pull/5 made these constants `uint32_t` via a cast.

**Description of changes:**
Avoid `-Wuseless-cast` warnings, don't cast `size_t` to `uint32_t` on 32-bit platforms.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
