### PR TITLE
Reduce Max Message Size to 24MB

### DIFF
--- a/include/aws/event-stream/event_stream.h
+++ b/include/aws/event-stream/event_stream.h
@@ -16,11 +16,9 @@
 AWS_PUSH_SANE_WARNING_LEVEL
 
 #define AWS_C_EVENT_STREAM_PACKAGE_ID 4
-/* max message size is technically unbounded on the client side, and validated on the server side but we don't want to
- * allocate large buffers in case of bugs. 256 MB is a reasonably large buffer size limit. Current service-
- * side max is 24 MB, likely to increase in future.
+/* Current service-side max is 24 MB, likely to increase in future.
  * This is encoded on the wire in 4 bytes, and could technically be larger (up to INT32_MAX). */
-#define AWS_EVENT_STREAM_MAX_MESSAGE_SIZE (256 * 1024 * 1024)
+#define AWS_EVENT_STREAM_MAX_MESSAGE_SIZE (24 * 1024 * 1024)
 
 /* Max total size for headers.
  * This is encoded on the wire in 4 bytes, and could technically be larger (up to INT32_MAX). */


### PR DESCRIPTION
*Description of changes:*
After internal discussion, we have decided that clients should validate that the message size is at most 24MB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
