### PR TITLE
make exports consistent

### DIFF
--- a/include/aws/event-stream/event_stream_exports.h
+++ b/include/aws/event-stream/event_stream_exports.h
@@ -4,7 +4,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-#if defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
+#if defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32)
 #    ifdef AWS_EVENT_STREAM_USE_IMPORT_EXPORT
 #        ifdef AWS_EVENT_STREAM_EXPORTS
 #            define AWS_EVENT_STREAM_API __declspec(dllexport)
@@ -15,15 +15,14 @@
 #        define AWS_EVENT_STREAM_API
 #    endif /* AWS_EVENT_STREAM_USE_IMPORT_EXPORT */
 
-#else /* defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32) */
+#else /* defined (AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined (_WIN32) */
 
-#    if ((__GNUC__ >= 4) || defined(__clang__)) && defined(AWS_EVENT_STREAM_USE_IMPORT_EXPORT) &&                      \
-        defined(AWS_EVENT_STREAM_EXPORTS)
+#    if defined(AWS_EVENT_STREAM_USE_IMPORT_EXPORT) && defined(AWS_EVENT_STREAM_EXPORTS)
 #        define AWS_EVENT_STREAM_API __attribute__((visibility("default")))
 #    else
 #        define AWS_EVENT_STREAM_API
-#    endif /* __GNUC__ >= 4 || defined(__clang__) */
+#    endif
 
-#endif /* defined (USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32) */
+#endif /* defined (AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined (_WIN32) */
 
 #endif /* AWS_EVENT_STREAM_EXPORTS_H */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make AWS_CRT_USE_WINDOWS_DLL_SEMANTICS the variable for forcing win semantics
remove gcc < 4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
