### PR TITLE
Fix path for diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ Total message overhead, including the prelude and both checksums, is 16 bytes.
 
 The following diagram shows the components that make up a message and a header. There are multiple headers per message.
 
-![Encoding Diagram](docs/encoding.png)
+![Encoding Diagram](docs/images/encoding.png)


### PR DESCRIPTION
*Issue #, if available:*

The path to the diagram image is wrong in the README file. So, instead of the picture, there's just [404 icon](https://github.com/awslabs/aws-c-event-stream/blob/v0.5.4/README.md#encoding).

*Description of changes:*

Fix the path.

The resulting README file can be found [here](https://github.com/awslabs/aws-c-event-stream/blob/772db62b1074f7e26f7911250265c7081d1d0efe/README.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
