### PR TITLE
Continuation termination callback support

### DIFF
--- a/include/aws/event-stream/event_stream_rpc_client.h
+++ b/include/aws/event-stream/event_stream_rpc_client.h
@@ -80,6 +80,11 @@ typedef void(aws_event_stream_rpc_client_on_connection_setup_fn)(
     void *user_data);
 
 /**
+ * Invoked when a connection has been completely destroyed.
+ */
+typedef void(aws_event_stream_rpc_client_on_connection_terminated_fn)(void *user_data);
+
+/**
  * Invoked whenever a message has been flushed to the channel.
  */
 typedef void(aws_event_stream_rpc_client_message_flush_fn)(int error_code, void *user_data);
@@ -99,6 +104,7 @@ struct aws_event_stream_rpc_client_connection_options {
     aws_event_stream_rpc_client_on_connection_setup_fn *on_connection_setup;
     aws_event_stream_rpc_client_connection_protocol_message_fn *on_connection_protocol_message;
     aws_event_stream_rpc_client_on_connection_shutdown_fn *on_connection_shutdown;
+    aws_event_stream_rpc_client_on_connection_terminated_fn *on_connection_terminated;
     void *user_data;
 };
 

--- a/include/aws/event-stream/event_stream_rpc_client.h
+++ b/include/aws/event-stream/event_stream_rpc_client.h
@@ -30,9 +30,15 @@ typedef void(aws_event_stream_rpc_client_stream_continuation_closed_fn)(
     struct aws_event_stream_rpc_client_continuation_token *token,
     void *user_data);
 
+/**
+* Invoked after a continuation has been fully destroyed.  Listeners know that no further callbacks are possible.
+*/
+typedef void(aws_event_stream_rpc_client_stream_continuation_terminated_fn)(void *user_data);
+
 struct aws_event_stream_rpc_client_stream_continuation_options {
     aws_event_stream_rpc_client_stream_continuation_fn *on_continuation;
     aws_event_stream_rpc_client_stream_continuation_closed_fn *on_continuation_closed;
+    aws_event_stream_rpc_client_stream_continuation_terminated_fn *on_continuation_terminated;
     void *user_data;
 };
 

--- a/include/aws/event-stream/event_stream_rpc_client.h
+++ b/include/aws/event-stream/event_stream_rpc_client.h
@@ -31,8 +31,8 @@ typedef void(aws_event_stream_rpc_client_stream_continuation_closed_fn)(
     void *user_data);
 
 /**
-* Invoked after a continuation has been fully destroyed.  Listeners know that no further callbacks are possible.
-*/
+ * Invoked after a continuation has been fully destroyed.  Listeners know that no further callbacks are possible.
+ */
 typedef void(aws_event_stream_rpc_client_stream_continuation_terminated_fn)(void *user_data);
 
 struct aws_event_stream_rpc_client_stream_continuation_options {

--- a/include/aws/event-stream/event_stream_rpc_client.h
+++ b/include/aws/event-stream/event_stream_rpc_client.h
@@ -10,6 +10,7 @@
 AWS_PUSH_SANE_WARNING_LEVEL
 
 struct aws_channel;
+struct aws_event_loop;
 struct aws_event_stream_rpc_client_connection;
 struct aws_event_stream_rpc_client_continuation_token;
 
@@ -153,6 +154,12 @@ AWS_EVENT_STREAM_API int aws_event_stream_rpc_client_connection_send_protocol_me
     const struct aws_event_stream_rpc_message_args *message_args,
     aws_event_stream_rpc_client_message_flush_fn *flush_fn,
     void *user_data);
+
+/**
+ * Returns the event loop that a connection is seated on.
+ */
+AWS_EVENT_STREAM_API struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop(
+    const struct aws_event_stream_rpc_client_connection *connection);
 
 /**
  * Create a new stream. continuation_option's callbacks will not be invoked, and nothing will be sent across the wire

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -39,6 +39,7 @@ struct aws_event_stream_rpc_client_connection {
     aws_event_stream_rpc_client_on_connection_setup_fn *on_connection_setup;
     aws_event_stream_rpc_client_connection_protocol_message_fn *on_connection_protocol_message;
     aws_event_stream_rpc_client_on_connection_shutdown_fn *on_connection_shutdown;
+    aws_event_stream_rpc_client_on_connection_terminated_fn *on_connection_terminated;
     void *user_data;
     bool bootstrap_owned;
     bool enable_read_back_pressure;
@@ -234,18 +235,31 @@ static int s_complete_and_clear_each_continuation(void *context, struct aws_hash
 static void s_clear_continuation_table(struct aws_event_stream_rpc_client_connection *connection) {
     AWS_ASSERT(!aws_event_stream_rpc_client_connection_is_open(connection));
 
+    struct aws_hash_table temp_table;
+    aws_hash_table_init(
+        &temp_table,
+        connection->allocator,
+        64,
+        aws_event_stream_rpc_hash_streamid,
+        aws_event_stream_rpc_streamid_eq,
+        NULL,
+        NULL);
+
     /* Use lock to ensure synchronization with code that adds entries to table.
      * Since connection was just marked closed, no further entries will be
-     * added to table once we acquire the lock. */
+     * added to table once we acquire the lock.
+     *
+     *  While no further entries can be added, there are concurrent execution paths where things can be
+     *  removed.  So rather than iterating the connection's table, swap it out for an empty one and iterate
+     *  the temporary table instead.  Removing from an empty table will be harmless.
+     */
     aws_mutex_lock(&connection->stream_lock);
-    aws_hash_table_foreach(&connection->continuation_table, s_mark_each_continuation_closed, NULL);
+    aws_hash_table_swap(&temp_table, &connection->continuation_table);
     aws_mutex_unlock(&connection->stream_lock);
 
-    /* Now release lock before invoking callbacks.
-     * It's safe to alter the table now without a lock, since no further
-     * entries can be added, and we've gone through the critical section
-     * above to ensure synchronization */
-    aws_hash_table_foreach(&connection->continuation_table, s_complete_and_clear_each_continuation, NULL);
+    aws_hash_table_foreach(&temp_table, s_mark_each_continuation_closed, NULL);
+    aws_hash_table_foreach(&temp_table, s_complete_and_clear_each_continuation, NULL);
+    aws_hash_table_clean_up(&temp_table);
 }
 
 int aws_event_stream_rpc_client_connection_connect(
@@ -277,6 +291,7 @@ int aws_event_stream_rpc_client_connection_connect(
     aws_mutex_init(&connection->stream_lock);
 
     connection->on_connection_shutdown = conn_options->on_connection_shutdown;
+    connection->on_connection_terminated = conn_options->on_connection_terminated;
     connection->on_connection_protocol_message = conn_options->on_connection_protocol_message;
     connection->on_connection_setup = conn_options->on_connection_setup;
     connection->user_data = conn_options->user_data;
@@ -341,7 +356,15 @@ static void s_destroy_connection(struct aws_event_stream_rpc_client_connection *
     AWS_LOGF_DEBUG(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: destroying connection.", (void *)connection);
     aws_hash_table_clean_up(&connection->continuation_table);
     aws_client_bootstrap_release(connection->bootstrap_ref);
+
+    aws_event_stream_rpc_client_on_connection_terminated_fn *terminated_fn = connection->on_connection_terminated;
+    void *terminated_user_data = connection->user_data;
+
     aws_mem_release(connection->allocator, connection);
+
+    if (terminated_fn) {
+        terminated_fn(terminated_user_data);
+    }
 }
 
 void aws_event_stream_rpc_client_connection_release(const struct aws_event_stream_rpc_client_connection *connection) {

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -464,13 +464,19 @@ static void s_on_protocol_message_written_fn(
         AWS_FATAL_ASSERT(message_args->continuation && "end stream flag was set but it wasn't on a continuation");
         aws_atomic_store_int(&message_args->continuation->is_closed, 1U);
 
+        int was_present = 0;
         aws_mutex_lock(&message_args->connection->stream_lock);
         aws_hash_table_remove(
-            &message_args->connection->continuation_table, &message_args->continuation->stream_id, NULL, NULL);
+            &message_args->connection->continuation_table, &message_args->continuation->stream_id, NULL, &was_present);
         aws_mutex_unlock(&message_args->connection->stream_lock);
 
-        /* Lock must NOT be held while invoking callback */
-        s_complete_continuation(message_args->continuation);
+        /*
+         * Whoever successfully removes the continuation from the table gets to complete it.
+         * Lock must NOT be held while invoking callback
+         */
+        if (was_present) {
+            s_complete_continuation(message_args->continuation);
+        }
     }
 
     message_args->flush_fn(error_code, message_args->user_data);
@@ -809,12 +815,18 @@ static void s_route_message_by_type(
                 (void *)connection,
                 (void *)continuation);
             aws_atomic_store_int(&continuation->is_closed, 1U);
+            int was_present = 0;
             aws_mutex_lock(&connection->stream_lock);
-            aws_hash_table_remove(&connection->continuation_table, &stream_id, NULL, NULL);
+            aws_hash_table_remove(&connection->continuation_table, &stream_id, NULL, &was_present);
             aws_mutex_unlock(&connection->stream_lock);
 
-            /* Note that we do not invoke callback while holding lock */
-            s_complete_continuation(continuation);
+            /*
+             * Whoever successfully removes the continuation from the table gets to complete it.
+             * Lock must NOT be held while invoking callback
+             */
+            if (was_present) {
+                s_complete_continuation(continuation);
+            }
         }
 
         aws_event_stream_rpc_client_continuation_release(continuation);

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -192,9 +192,7 @@ static void s_on_channel_shutdown_fn(
     aws_event_stream_rpc_client_connection_release(connection);
 }
 
-/* Set each continuation's is_closed=true.
- * A lock MUST be held while calling this.
- * For use with aws_hash_table_foreach(). */
+/* Set each continuation's is_closed=true. */
 static int s_mark_each_continuation_closed(void *context, struct aws_hash_element *p_element) {
     (void)context;
     struct aws_event_stream_rpc_client_continuation_token *continuation = p_element->value;

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -800,7 +800,6 @@ static void s_route_message_by_type(
         aws_mutex_unlock(&connection->stream_lock);
 
         continuation->continuation_fn(continuation, &message_args, continuation->user_data);
-        aws_event_stream_rpc_client_continuation_release(continuation);
 
         /* if it was a terminal stream message purge it from the hash table. The delete will decref the continuation. */
         if (message_flags & AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_TERMINATE_STREAM) {
@@ -817,6 +816,8 @@ static void s_route_message_by_type(
             /* Note that we do not invoke callback while holding lock */
             s_complete_continuation(continuation);
         }
+
+        aws_event_stream_rpc_client_continuation_release(continuation);
     } else {
         if (message_type <= AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_APPLICATION_ERROR ||
             message_type >= AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_COUNT) {


### PR DESCRIPTION
* adds a termination callback for continuations.  This gives us a safe, guaranteed (regardless of state) timepoint after which we know no further callbacks are possible for binding object lifetime management.
* adds a termination callback for connections.  This gives us a safe, guaranteed (regardless of state) timepoint after which we know no further callbacks are possible for binding object lifetime management.
* relaxes the server-side constraint around stream id lookup for incoming messages.  A terminate-stream-flagged message with no corresponding continuation is no longer a protocol error in order to support simultaneous close.  This probably should have been done three years ago when https://github.com/awslabs/aws-c-event-stream/pull/83 was applied.
* Fixes a continuation table race condition where we could be iterating the continuation table while a concurrent execution path attempts to remove an entry
* Eventstream connections now select and track their event loop before the connection attempt.  This allows us to reason about whether or not a callback can concurrently overlap binding logic (ie, if we're in the event loop, it cannot).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
