### PR TITLE
Refactor client connection for thread safety

### DIFF
--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -2,19 +2,18 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-#include <aws/event-stream/event_stream_channel_handler.h>
+
 #include <aws/event-stream/event_stream_rpc_client.h>
-#include <aws/event-stream/private/event_stream_rpc_priv.h>
 
 #include <aws/common/atomics.h>
 #include <aws/common/hash_table.h>
 #include <aws/common/mutex.h>
-
+#include <aws/event-stream/event_stream_channel_handler.h>
+#include <aws/event-stream/private/event_stream_rpc_priv.h>
 #include <aws/io/channel_bootstrap.h>
+#include <aws/io/event_loop.h>
 
 #include <inttypes.h>
-
-#include "aws/io/event_loop.h"
 
 #ifdef _MSC_VER
 /* allow declared initializer using address of automatic variable */
@@ -27,25 +26,32 @@
 static void s_clear_continuation_table(struct aws_event_stream_rpc_client_connection *connection);
 
 struct aws_event_stream_rpc_client_connection {
+    /* const-at-creation data */
     struct aws_allocator *allocator;
-    struct aws_hash_table continuation_table;
     struct aws_client_bootstrap *bootstrap_ref;
     struct aws_event_loop *event_loop;
-    struct aws_atomic_var ref_count;
-    struct aws_channel *channel;
-    struct aws_channel_handler *event_stream_handler;
-    uint32_t latest_stream_id;
-    struct aws_mutex stream_lock;
-    struct aws_atomic_var is_open;
-    struct aws_atomic_var handshake_state;
-    size_t initial_window_size;
     aws_event_stream_rpc_client_on_connection_setup_fn *on_connection_setup;
     aws_event_stream_rpc_client_connection_protocol_message_fn *on_connection_protocol_message;
     aws_event_stream_rpc_client_on_connection_shutdown_fn *on_connection_shutdown;
     aws_event_stream_rpc_client_on_connection_terminated_fn *on_connection_terminated;
     void *user_data;
-    bool bootstrap_owned;
-    bool enable_read_back_pressure;
+
+    /* independent */
+    struct aws_atomic_var ref_count;
+
+    /* private to event loop thread.  unsafe to access otherwise. */
+    struct aws_channel *channel;
+    struct aws_channel_handler *event_stream_handler;
+
+    /* lock and synchronized data */
+    struct aws_mutex stream_lock;
+    struct {
+        struct aws_hash_table continuation_table;
+        uint32_t latest_stream_id;
+        bool is_open;
+        enum aws_event_stream_connection_handshake_state handshake_state;
+        bool bootstrap_owned;
+    } synced_data;
 };
 
 struct aws_event_stream_rpc_client_continuation_token {
@@ -65,14 +71,17 @@ static void s_on_message_received(struct aws_event_stream_message *message, int 
 static int s_create_connection_on_channel(
     struct aws_event_stream_rpc_client_connection *connection,
     struct aws_channel *channel) {
+
+    AWS_FATAL_ASSERT(aws_event_loop_thread_is_callers_thread(connection->event_loop));
+
     struct aws_channel_handler *event_stream_handler = NULL;
     struct aws_channel_slot *slot = NULL;
 
     struct aws_event_stream_channel_handler_options handler_options = {
         .on_message_received = s_on_message_received,
         .user_data = connection,
-        .initial_window_size = connection->initial_window_size,
-        .manual_window_management = connection->enable_read_back_pressure,
+        .initial_window_size = 0,
+        .manual_window_management = false,
     };
 
     AWS_LOGF_TRACE(
@@ -142,10 +151,18 @@ static void s_on_channel_setup_fn(
         (void *)channel);
 
     if (!error_code) {
-        connection->bootstrap_owned = true;
+        /* Q: Did we fix DNS failures to always call back on the event loop in general or just for MQTT5? */
+        AWS_FATAL_ASSERT(aws_event_loop_thread_is_callers_thread(connection->event_loop));
+
+        aws_mutex_lock(&connection->stream_lock);
+        connection->synced_data.bootstrap_owned = true;
+        aws_mutex_unlock(&connection->stream_lock);
+
         if (s_create_connection_on_channel(connection, channel)) {
             int last_error = aws_last_error();
             connection->on_connection_setup(NULL, last_error, connection->user_data);
+
+            /* we have to shut down the successfully-created channel, so we don't want to release the connection yet */
             aws_channel_shutdown(channel, last_error);
             return;
         }
@@ -155,13 +172,24 @@ static void s_on_channel_setup_fn(
             "id=%p: successful event-stream channel setup %p",
             (void *)connection,
             (void *)channel);
+
+        /* keep the connection alive past this function */
         aws_event_stream_rpc_client_connection_acquire(connection);
         connection->on_connection_setup(connection, AWS_OP_SUCCESS, connection->user_data);
-        aws_event_stream_rpc_client_connection_release(connection);
     } else {
         connection->on_connection_setup(NULL, error_code, connection->user_data);
-        aws_event_stream_rpc_client_connection_release(connection);
     }
+
+    /*
+     * 2 -> 1 on a successful connection, 1 -> 0 on a failed one
+     *
+     * Note that the 1 ref is the channel's hold on the connection.  The user is required to acquire the connection
+     * in the setup callback to avoid early destruction.
+     *
+     * A corollary of this is that if you release the connection without calling close first, it will stay alive and
+     * leak.
+     */
+    aws_event_stream_rpc_client_connection_release(connection);
 }
 
 static void s_on_channel_shutdown_fn(
@@ -172,15 +200,25 @@ static void s_on_channel_shutdown_fn(
     (void)bootstrap;
 
     struct aws_event_stream_rpc_client_connection *connection = user_data;
+    AWS_FATAL_ASSERT(aws_event_loop_thread_is_callers_thread(connection->event_loop));
+
     AWS_LOGF_DEBUG(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: on_channel_shutdown_fn invoked with error_code %d with channel %p",
         (void *)connection,
         error_code,
         (void *)channel);
-    aws_atomic_store_int(&connection->is_open, 0u);
 
-    if (connection->bootstrap_owned) {
+    bool is_externally_visible_shutdown = false;
+    aws_mutex_lock(&connection->stream_lock);
+    connection->synced_data.is_open = false;
+    is_externally_visible_shutdown = connection->synced_data.bootstrap_owned;
+    aws_mutex_unlock(&connection->stream_lock);
+
+    connection->channel = NULL;
+    connection->event_stream_handler = NULL;
+
+    if (is_externally_visible_shutdown) {
         s_clear_continuation_table(connection);
 
         aws_event_stream_rpc_client_connection_acquire(connection);
@@ -255,7 +293,7 @@ static void s_clear_continuation_table(struct aws_event_stream_rpc_client_connec
      *  the temporary table instead.  Removing from an empty table will be harmless.
      */
     aws_mutex_lock(&connection->stream_lock);
-    aws_hash_table_swap(&temp_table, &connection->continuation_table);
+    aws_hash_table_swap(&temp_table, &connection->synced_data.continuation_table);
     aws_mutex_unlock(&connection->stream_lock);
 
     aws_hash_table_foreach(&temp_table, s_mark_each_continuation_closed, NULL);
@@ -277,10 +315,6 @@ int aws_event_stream_rpc_client_connection_connect(
 
     AWS_LOGF_TRACE(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: creating new connection", (void *)connection);
 
-    if (!connection) {
-        return AWS_OP_ERR;
-    }
-
     connection->allocator = allocator;
     aws_atomic_init_int(&connection->ref_count, 1);
     connection->bootstrap_ref = conn_options->bootstrap;
@@ -289,8 +323,8 @@ int aws_event_stream_rpc_client_connection_connect(
     /* this is released in the connection release which gets called regardless of if this function is successful or
      * not*/
     aws_client_bootstrap_acquire(connection->bootstrap_ref);
-    aws_atomic_init_int(&connection->handshake_state, CONNECTION_HANDSHAKE_STATE_INITIALIZED);
-    aws_atomic_init_int(&connection->is_open, 1);
+    connection->synced_data.handshake_state = CONNECTION_HANDSHAKE_STATE_INITIALIZED;
+    connection->synced_data.is_open = true;
     aws_mutex_init(&connection->stream_lock);
 
     connection->on_connection_shutdown = conn_options->on_connection_shutdown;
@@ -300,7 +334,7 @@ int aws_event_stream_rpc_client_connection_connect(
     connection->user_data = conn_options->user_data;
 
     if (aws_hash_table_init(
-            &connection->continuation_table,
+            &connection->synced_data.continuation_table,
             allocator,
             64,
             aws_event_stream_rpc_hash_streamid,
@@ -323,7 +357,6 @@ int aws_event_stream_rpc_client_connection_connect(
         .user_data = connection,
         .host_name = conn_options->host_name,
         .port = conn_options->port,
-        .enable_read_back_pressure = false,
         .setup_callback = s_on_channel_setup_fn,
         .shutdown_callback = s_on_channel_shutdown_fn,
         .requested_event_loop = connection->event_loop,
@@ -358,8 +391,9 @@ void aws_event_stream_rpc_client_connection_acquire(const struct aws_event_strea
 
 static void s_destroy_connection(struct aws_event_stream_rpc_client_connection *connection) {
     AWS_LOGF_DEBUG(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: destroying connection.", (void *)connection);
-    aws_hash_table_clean_up(&connection->continuation_table);
+    aws_hash_table_clean_up(&connection->synced_data.continuation_table);
     aws_client_bootstrap_release(connection->bootstrap_ref);
+    aws_mutex_clean_up(&connection->stream_lock);
 
     aws_event_stream_rpc_client_on_connection_terminated_fn *terminated_fn = connection->on_connection_terminated;
     void *terminated_user_data = connection->user_data;
@@ -393,6 +427,50 @@ void aws_event_stream_rpc_client_connection_release(const struct aws_event_strea
     }
 }
 
+struct aws_event_stream_client_connection_close_task {
+    struct aws_allocator *allocator;
+
+    struct aws_task base;
+    struct aws_event_stream_rpc_client_connection *connection;
+    int error_code;
+};
+
+static void s_aws_event_stream_client_connection_close_task_destroy(
+    struct aws_event_stream_client_connection_close_task *task) {
+    aws_event_stream_rpc_client_connection_release(task->connection);
+    aws_mem_release(task->allocator, task);
+}
+
+static void s_close_connection(struct aws_task *task, void *arg, enum aws_task_status status) {
+    (void)task;
+    (void)status;
+
+    struct aws_event_stream_client_connection_close_task *close_task = arg;
+
+    AWS_FATAL_ASSERT(aws_event_loop_thread_is_callers_thread(close_task->connection->event_loop));
+
+    if (close_task->connection->channel != NULL) {
+        aws_channel_shutdown(close_task->connection->channel, close_task->error_code);
+    }
+
+    s_aws_event_stream_client_connection_close_task_destroy(close_task);
+}
+
+static struct aws_event_stream_client_connection_close_task *s_aws_event_stream_client_connection_close_task_new(
+    struct aws_allocator *allocator,
+    struct aws_event_stream_rpc_client_connection *connection,
+    int error_code) {
+    struct aws_event_stream_client_connection_close_task *task =
+        aws_mem_calloc(allocator, 1, sizeof(struct aws_event_stream_client_connection_close_task));
+    task->allocator = allocator;
+    aws_task_init(&task->base, s_close_connection, task, "aws_event_stream_client_connection_close_task");
+    task->connection = connection;
+    task->error_code = error_code;
+    aws_event_stream_rpc_client_connection_acquire(connection);
+
+    return task;
+}
+
 void aws_event_stream_rpc_client_connection_close(
     struct aws_event_stream_rpc_client_connection *connection,
     int shutdown_error_code) {
@@ -403,22 +481,32 @@ void aws_event_stream_rpc_client_connection_close(
         (void *)connection,
         aws_error_debug_str(shutdown_error_code));
 
-    size_t expect_open = 1U;
-    if (aws_atomic_compare_exchange_int(&connection->is_open, &expect_open, 0U)) {
-        aws_channel_shutdown(connection->channel, shutdown_error_code);
+    bool should_close = false;
+    aws_mutex_lock(&connection->stream_lock);
+    should_close = connection->synced_data.is_open;
+    connection->synced_data.is_open = false;
+    aws_mutex_unlock(&connection->stream_lock);
 
-        if (!connection->bootstrap_owned) {
-            s_clear_continuation_table(connection);
-
-            aws_event_stream_rpc_client_connection_release(connection);
-        }
+    if (should_close) {
+        /* We may need to access the channel, which is only allowed on the event loop thread. */
+        struct aws_event_stream_client_connection_close_task *close_task =
+            s_aws_event_stream_client_connection_close_task_new(connection->allocator, connection, shutdown_error_code);
+        aws_event_loop_schedule_task_now(connection->event_loop, &close_task->base);
     } else {
-        AWS_LOGF_TRACE(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: connection already closed.", (void *)connection);
+        AWS_LOGF_INFO(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: connection already closed.", (void *)connection);
     }
 }
 
 bool aws_event_stream_rpc_client_connection_is_open(const struct aws_event_stream_rpc_client_connection *connection) {
-    return aws_atomic_load_int(&connection->is_open) == 1U;
+    struct aws_event_stream_rpc_client_connection *mutable_connection =
+        (struct aws_event_stream_rpc_client_connection *)connection;
+
+    bool is_open = false;
+    aws_mutex_lock(&mutable_connection->stream_lock);
+    is_open = connection->synced_data.is_open;
+    aws_mutex_unlock(&mutable_connection->stream_lock);
+
+    return is_open;
 }
 
 struct event_stream_connection_send_message_args {
@@ -433,71 +521,25 @@ struct event_stream_connection_send_message_args {
     bool terminate_connection;
 };
 
-static void s_on_protocol_message_written_fn(
-    struct aws_event_stream_message *message,
-    int error_code,
-    void *user_data) {
-    (void)message;
-
-    struct event_stream_connection_send_message_args *message_args = user_data;
-    AWS_LOGF_TRACE(
-        AWS_LS_EVENT_STREAM_RPC_CLIENT,
-        "id=%p: message %p flushed to channel.",
-        (void *)message_args->connection,
-        (void *)message);
-
-    if (message_args->message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
-        AWS_LOGF_TRACE(
-            AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: connect message flushed to the wire.",
-            (void *)message_args->connection);
+static void s_event_stream_connection_send_message_args_delete(struct event_stream_connection_send_message_args *args) {
+    if (args == NULL) {
+        return;
     }
 
-    if (message_args->end_stream) {
-        AWS_LOGF_DEBUG(
-            AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: the end stream flag was set, closing continuation %p.",
-            (void *)message_args->connection,
-            (void *)message_args->continuation);
-        AWS_FATAL_ASSERT(message_args->continuation && "end stream flag was set but it wasn't on a continuation");
-        aws_atomic_store_int(&message_args->continuation->is_closed, 1U);
-
-        int was_present = 0;
-        aws_mutex_lock(&message_args->connection->stream_lock);
-        aws_hash_table_remove(
-            &message_args->connection->continuation_table, &message_args->continuation->stream_id, NULL, &was_present);
-        aws_mutex_unlock(&message_args->connection->stream_lock);
-
-        /*
-         * Whoever successfully removes the continuation from the table gets to complete it.
-         * Lock must NOT be held while invoking callback
-         */
-        if (was_present) {
-            s_complete_continuation(message_args->continuation);
-        }
+    if (args->continuation) {
+        aws_event_stream_rpc_client_continuation_release(args->continuation);
     }
 
-    message_args->flush_fn(error_code, message_args->user_data);
-
-    if (message_args->terminate_connection) {
-        AWS_LOGF_DEBUG(
-            AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: terminate_connection flag was specified. Shutting down the connection.",
-            (void *)message_args->connection);
-        aws_event_stream_rpc_client_connection_close(message_args->connection, AWS_ERROR_SUCCESS);
+    if (args->connection) {
+        aws_event_stream_rpc_client_connection_release(args->connection);
     }
 
-    aws_event_stream_rpc_client_connection_release(message_args->connection);
+    aws_event_stream_message_clean_up(&args->message);
 
-    if (message_args->continuation) {
-        aws_event_stream_rpc_client_continuation_release(message_args->continuation);
-    }
-
-    aws_event_stream_message_clean_up(&message_args->message);
-    aws_mem_release(message_args->allocator, message_args);
+    aws_mem_release(args->allocator, args);
 }
 
-static int s_send_protocol_message(
+static struct event_stream_connection_send_message_args *s_event_stream_connection_send_message_args_new(
     struct aws_event_stream_rpc_client_connection *connection,
     struct aws_event_stream_rpc_client_continuation_token *continuation,
     struct aws_byte_cursor *operation_name,
@@ -506,30 +548,8 @@ static int s_send_protocol_message(
     aws_event_stream_rpc_client_message_flush_fn *flush_fn,
     void *user_data) {
 
-    AWS_LOGF_TRACE(
-        AWS_LS_EVENT_STREAM_RPC_CLIENT,
-        "id=%p: sending message. continuation: %p, stream id %" PRId32,
-        (void *)connection,
-        (void *)continuation,
-        stream_id);
-
-    size_t connect_handshake_state = aws_atomic_load_int(&connection->handshake_state);
-    AWS_LOGF_TRACE(
-        AWS_LS_EVENT_STREAM_RPC_CLIENT,
-        "id=%p: handshake completion value %zu",
-        (void *)connection,
-        connect_handshake_state);
-
-    /* handshake step 1 is a connect message being received. Handshake 2 is the connect ack being sent.
-     * no messages other than connect and connect ack are allowed until this count reaches 2. */
-    if (connect_handshake_state != CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED &&
-        message_args->message_type < AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
-        AWS_LOGF_ERROR(
-            AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: handshake not completed, only a connect message can be sent.",
-            (void *)connection);
-        return aws_raise_error(AWS_ERROR_EVENT_STREAM_RPC_PROTOCOL_ERROR);
-    }
+    struct aws_array_list headers_list;
+    AWS_ZERO_STRUCT(headers_list);
 
     struct event_stream_connection_send_message_args *args =
         aws_mem_calloc(connection->allocator, 1, sizeof(struct event_stream_connection_send_message_args));
@@ -537,12 +557,14 @@ static int s_send_protocol_message(
     args->user_data = user_data;
     args->message_type = message_args->message_type;
     args->connection = connection;
+    aws_event_stream_rpc_client_connection_acquire(connection);
+
     args->flush_fn = flush_fn;
 
     if (continuation) {
         AWS_LOGF_TRACE(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: sending message on continuation %p",
+            "id=%p: creating message on continuation %p",
             (void *)connection,
             (void *)continuation);
         args->continuation = continuation;
@@ -564,40 +586,22 @@ static int s_send_protocol_message(
         args->terminate_connection = true;
     }
 
-    if (message_args->message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
-        AWS_LOGF_DEBUG(
-            AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: sending connect message, waiting on connect ack",
-            (void *)connection);
-        aws_atomic_store_int(&connection->handshake_state, CONNECTION_HANDSHAKE_STATE_CONNECT_PROCESSED);
-    }
-
     args->flush_fn = flush_fn;
 
     size_t headers_count = 0;
 
     if (operation_name) {
         if (aws_add_size_checked(message_args->headers_count, 4, &headers_count)) {
-            return AWS_OP_ERR;
+            goto error;
         }
     } else {
         if (aws_add_size_checked(message_args->headers_count, 3, &headers_count)) {
-            return AWS_OP_ERR;
+            goto error;
         }
     }
 
-    struct aws_array_list headers_list;
-    AWS_ZERO_STRUCT(headers_list);
-
-    if (aws_array_list_init_dynamic(
-            &headers_list, connection->allocator, headers_count, sizeof(struct aws_event_stream_header_value_pair))) {
-        AWS_LOGF_ERROR(
-            AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: an error occurred while initializing the headers list %s",
-            (void *)connection,
-            aws_error_debug_str(aws_last_error()));
-        goto args_allocated_before_failure;
-    }
+    aws_array_list_init_dynamic(
+        &headers_list, connection->allocator, headers_count, sizeof(struct aws_event_stream_header_value_pair));
 
     /* since we preallocated the space for the headers, these can't fail, but we'll go ahead an assert on them just in
      * case */
@@ -636,41 +640,247 @@ static int s_send_protocol_message(
             0));
     }
 
-    int message_init_err_code =
+    int init_result =
         aws_event_stream_message_init(&args->message, connection->allocator, &headers_list, message_args->payload);
     aws_array_list_clean_up(&headers_list);
 
-    if (message_init_err_code) {
+    if (init_result) {
         AWS_LOGF_ERROR(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
             "id=%p: message init failed with error %s",
             (void *)connection,
             aws_error_debug_str(aws_last_error()));
-        goto args_allocated_before_failure;
+        goto error;
     }
 
-    aws_event_stream_rpc_client_connection_acquire(connection);
+    return args;
 
-    if (aws_event_stream_channel_handler_write_message(
-            connection->event_stream_handler, &args->message, s_on_protocol_message_written_fn, args)) {
-        AWS_LOGF_ERROR(
+error:
+
+    s_event_stream_connection_send_message_args_delete(args);
+
+    return NULL;
+}
+
+struct aws_event_stream_client_connection_send_message_task {
+    struct aws_allocator *allocator;
+
+    struct aws_task base;
+    struct event_stream_connection_send_message_args *message_args;
+};
+
+static void s_aws_event_stream_client_connection_send_message_task_destroy(
+    struct aws_event_stream_client_connection_send_message_task *task) {
+
+    if (task->message_args != NULL) {
+        s_event_stream_connection_send_message_args_delete(task->message_args);
+    }
+
+    aws_mem_release(task->allocator, task);
+}
+
+static void s_on_protocol_message_written_fn(
+    struct aws_event_stream_message *message,
+    int error_code,
+    void *user_data) {
+    (void)message;
+
+    struct event_stream_connection_send_message_args *message_args = user_data;
+
+    if (message_args->message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT) {
+        AWS_LOGF_DEBUG(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
-            "id=%p: writing message failed with error %s",
-            (void *)connection,
-            aws_error_debug_str(aws_last_error()));
-        goto message_initialized_before_failure;
+            "id=%p: connect message flushed to the wire.",
+            (void *)message_args->connection);
+    } else {
+        AWS_LOGF_TRACE(
+            AWS_LS_EVENT_STREAM_RPC_CLIENT,
+            "id=%p: message %p flushed to channel.",
+            (void *)message_args->connection,
+            (void *)message);
     }
+
+    if (message_args->end_stream) {
+        AWS_LOGF_DEBUG(
+            AWS_LS_EVENT_STREAM_RPC_CLIENT,
+            "id=%p: the end stream flag was set, closing continuation %p.",
+            (void *)message_args->connection,
+            (void *)message_args->continuation);
+        AWS_FATAL_ASSERT(message_args->continuation && "end stream flag was set but it wasn't on a continuation");
+        aws_atomic_store_int(&message_args->continuation->is_closed, 1U);
+
+        int was_present = 0;
+        aws_mutex_lock(&message_args->connection->stream_lock);
+        aws_hash_table_remove(
+            &message_args->connection->synced_data.continuation_table,
+            &message_args->continuation->stream_id,
+            NULL,
+            &was_present);
+        aws_mutex_unlock(&message_args->connection->stream_lock);
+
+        /*
+         * Whoever successfully removes the continuation from the table gets to complete it.
+         * Lock must NOT be held while invoking callback
+         */
+        if (was_present) {
+            s_complete_continuation(message_args->continuation);
+        }
+    }
+
+    message_args->flush_fn(error_code, message_args->user_data);
+
+    if (message_args->terminate_connection) {
+        AWS_LOGF_DEBUG(
+            AWS_LS_EVENT_STREAM_RPC_CLIENT,
+            "id=%p: terminate_connection flag was specified. Shutting down the connection.",
+            (void *)message_args->connection);
+        aws_event_stream_rpc_client_connection_close(message_args->connection, AWS_ERROR_SUCCESS);
+    }
+
+    s_event_stream_connection_send_message_args_delete(message_args);
+}
+
+static void s_send_message_task_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
+    (void)task;
+
+    struct aws_event_stream_client_connection_send_message_task *send_task = arg;
+    struct event_stream_connection_send_message_args *message_args = send_task->message_args;
+    struct aws_event_stream_rpc_client_connection *connection = message_args->connection;
+    enum aws_event_stream_rpc_message_type message_type = message_args->message_type;
+
+    AWS_FATAL_ASSERT(aws_event_loop_thread_is_callers_thread(message_args->connection->event_loop));
+
+    int failure_error_code = AWS_ERROR_UNKNOWN;
+    bool should_fail = true;
+    if (status == AWS_TASK_STATUS_RUN_READY) {
+        bool is_open = false;
+        bool is_handshake_state_valid = false;
+        aws_mutex_lock(&connection->stream_lock);
+
+        is_open = connection->synced_data.is_open;
+        switch (connection->synced_data.handshake_state) {
+            case CONNECTION_HANDSHAKE_STATE_INITIALIZED:
+                is_handshake_state_valid = message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT;
+                if (is_handshake_state_valid) {
+                    connection->synced_data.handshake_state = CONNECTION_HANDSHAKE_STATE_CONNECT_PROCESSED;
+                }
+                break;
+
+            case CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED:
+                is_handshake_state_valid = message_type != AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT &&
+                                           message_type != AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT_ACK;
+                break;
+
+            default:
+                // nothing is valid to send while awaiting the connack
+                break;
+        }
+
+        aws_mutex_unlock(&connection->stream_lock);
+
+        if (!is_open) {
+            AWS_LOGF_INFO(
+                AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: connection closed, cannot send messages", (void *)connection);
+            failure_error_code = AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED;
+            goto should_fail_block;
+        }
+
+        if (connection->channel == NULL || connection->event_stream_handler == NULL) {
+            AWS_LOGF_INFO(
+                AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: channel destroyed, cannot send messages", (void *)connection);
+            failure_error_code = AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED;
+            goto should_fail_block;
+        }
+
+        if (!is_handshake_state_valid) {
+            AWS_LOGF_ERROR(
+                AWS_LS_EVENT_STREAM_RPC_CLIENT,
+                "id=%p: invalid handshake state for message type (%d)",
+                (void *)connection,
+                (int)message_args->message_type);
+            failure_error_code = AWS_ERROR_EVENT_STREAM_RPC_PROTOCOL_ERROR;
+            goto should_fail_block;
+        }
+
+        should_fail = false;
+    }
+
+    if (!should_fail) {
+        if (aws_event_stream_channel_handler_write_message(
+                connection->event_stream_handler,
+                &message_args->message,
+                s_on_protocol_message_written_fn,
+                message_args)) {
+            failure_error_code = aws_last_error();
+            should_fail = true;
+            AWS_LOGF_ERROR(
+                AWS_LS_EVENT_STREAM_RPC_CLIENT,
+                "id=%p: writing message failed with error %s",
+                (void *)connection,
+                aws_error_debug_str(failure_error_code));
+        } else {
+            /* ownership transfer to flush callback, so don't destroy on task destruction */
+            send_task->message_args = NULL;
+        }
+    }
+
+should_fail_block:
+
+    if (should_fail) {
+        AWS_FATAL_ASSERT(send_task->message_args != NULL);
+
+        /*
+         * We didn't transfer ownership of the message args to the flush callback via a successful handler send
+         * call.  We must invoke a failed callback.
+         */
+        if (message_args->flush_fn != NULL) {
+            (*message_args->flush_fn)(failure_error_code, message_args->user_data);
+        }
+
+        /* Fail-to-send is connection fatal */
+        if (connection->channel != NULL) {
+            aws_channel_shutdown(connection->channel, failure_error_code);
+        }
+    }
+
+    s_aws_event_stream_client_connection_send_message_task_destroy(send_task);
+}
+
+static struct aws_event_stream_client_connection_send_message_task *
+    s_aws_event_stream_client_connection_send_message_task_new(
+        struct aws_allocator *allocator,
+        struct event_stream_connection_send_message_args *message_args) {
+    struct aws_event_stream_client_connection_send_message_task *task =
+        aws_mem_calloc(allocator, 1, sizeof(struct aws_event_stream_client_connection_send_message_task));
+    task->allocator = allocator;
+    aws_task_init(&task->base, s_send_message_task_fn, task, "aws_event_stream_client_connection_send_message_task");
+    task->message_args = message_args;
+
+    return task;
+}
+
+static int s_send_protocol_message(
+    struct aws_event_stream_rpc_client_connection *connection,
+    struct aws_event_stream_rpc_client_continuation_token *continuation,
+    struct aws_byte_cursor *operation_name,
+    const struct aws_event_stream_rpc_message_args *message_args,
+    int32_t stream_id,
+    aws_event_stream_rpc_client_message_flush_fn *flush_fn,
+    void *user_data) {
+
+    AWS_LOGF_TRACE(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: attempting to send protocol message", (void *)connection);
+
+    struct event_stream_connection_send_message_args *args = s_event_stream_connection_send_message_args_new(
+        connection, continuation, operation_name, message_args, stream_id, flush_fn, user_data);
+    if (args == NULL) {
+        return AWS_OP_ERR;
+    }
+
+    struct aws_event_stream_client_connection_send_message_task *task =
+        s_aws_event_stream_client_connection_send_message_task_new(connection->allocator, args);
+    aws_event_loop_schedule_task_now(connection->event_loop, &task->base);
 
     return AWS_OP_SUCCESS;
-
-message_initialized_before_failure:
-    aws_event_stream_message_clean_up(&args->message);
-
-args_allocated_before_failure:
-    aws_mem_release(args->allocator, args);
-    aws_event_stream_rpc_client_connection_release(connection);
-
-    return AWS_OP_ERR;
 }
 
 int aws_event_stream_rpc_client_connection_send_protocol_message(
@@ -678,9 +888,6 @@ int aws_event_stream_rpc_client_connection_send_protocol_message(
     const struct aws_event_stream_rpc_message_args *message_args,
     aws_event_stream_rpc_client_message_flush_fn *flush_fn,
     void *user_data) {
-    if (!aws_event_stream_rpc_client_connection_is_open(connection)) {
-        return aws_raise_error(AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED);
-    }
 
     return s_send_protocol_message(connection, NULL, NULL, message_args, 0, flush_fn, user_data);
 }
@@ -742,10 +949,12 @@ static void s_route_message_by_type(
         .message_type = message_type,
     };
 
-    size_t handshake_complete = aws_atomic_load_int(&connection->handshake_state);
+    aws_mutex_lock(&connection->stream_lock);
+    enum aws_event_stream_connection_handshake_state handshake_state = connection->synced_data.handshake_state;
+    aws_mutex_unlock(&connection->stream_lock);
 
     /* make sure if this is not a CONNECT message being received, the handshake has been completed. */
-    if (handshake_complete < CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED &&
+    if (handshake_state < CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED &&
         message_type != AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT_ACK) {
         AWS_LOGF_ERROR(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
@@ -776,9 +985,9 @@ static void s_route_message_by_type(
 
         aws_mutex_lock(&connection->stream_lock);
         struct aws_hash_element *continuation_element = NULL;
-        if (aws_hash_table_find(&connection->continuation_table, &stream_id, &continuation_element) ||
+        if (aws_hash_table_find(&connection->synced_data.continuation_table, &stream_id, &continuation_element) ||
             !continuation_element) {
-            bool old_stream_id = stream_id <= connection->latest_stream_id;
+            bool old_stream_id = stream_id <= connection->synced_data.latest_stream_id;
             aws_mutex_unlock(&connection->stream_lock);
             if (!old_stream_id) {
                 AWS_LOGF_ERROR(
@@ -815,7 +1024,7 @@ static void s_route_message_by_type(
             aws_atomic_store_int(&continuation->is_closed, 1U);
             int was_present = 0;
             aws_mutex_lock(&connection->stream_lock);
-            aws_hash_table_remove(&connection->continuation_table, &stream_id, NULL, &was_present);
+            aws_hash_table_remove(&connection->synced_data.continuation_table, &stream_id, NULL, &was_present);
             aws_mutex_unlock(&connection->stream_lock);
 
             /*
@@ -842,7 +1051,15 @@ static void s_route_message_by_type(
         }
 
         if (message_type == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT_ACK) {
-            if (handshake_complete != CONNECTION_HANDSHAKE_STATE_CONNECT_PROCESSED) {
+            aws_mutex_lock(&connection->stream_lock);
+            bool bad_handshake_state =
+                connection->synced_data.handshake_state != CONNECTION_HANDSHAKE_STATE_CONNECT_PROCESSED;
+            if (!bad_handshake_state) {
+                connection->synced_data.handshake_state = CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED;
+            }
+            aws_mutex_unlock(&connection->stream_lock);
+
+            if (bad_handshake_state) {
                 AWS_LOGF_ERROR(
                     AWS_LS_EVENT_STREAM_RPC_CLIENT,
                     "id=%p: connect ack received but the handshake is already completed. Only one is allowed.",
@@ -852,7 +1069,7 @@ static void s_route_message_by_type(
                     connection, AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PROTOCOL_ERROR, 0, &s_connect_not_completed_error);
                 return;
             }
-            aws_atomic_store_int(&connection->handshake_state, CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED);
+
             AWS_LOGF_INFO(
                 AWS_LS_EVENT_STREAM_RPC_CLIENT,
                 "id=%p: connect ack received, connection handshake completed",
@@ -1028,27 +1245,15 @@ int aws_event_stream_rpc_client_continuation_activate(
     AWS_LOGF_TRACE(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: activating continuation", (void *)continuation);
     int ret_val = AWS_OP_ERR;
 
-    aws_mutex_lock(&continuation->connection->stream_lock);
-
     if (continuation->stream_id) {
         AWS_LOGF_ERROR(
             AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: stream has already been activated", (void *)continuation);
-        aws_raise_error(AWS_ERROR_INVALID_STATE);
-        goto clean_up;
+        return aws_raise_error(AWS_ERROR_INVALID_STATE);
     }
 
-    /* Even though is_open is atomic, we need to hold a lock while checking it.
-     * This lets us coordinate with code that sets is_open to false. */
-    if (!aws_event_stream_rpc_client_connection_is_open(continuation->connection)) {
-        AWS_LOGF_ERROR(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: stream's connection is not open", (void *)continuation);
-        aws_raise_error(AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED);
-        goto clean_up;
-    }
+    aws_mutex_lock(&continuation->connection->stream_lock);
 
-    /* we cannot update the connection's stream id until we're certain the message at least made it to the wire, because
-     * the next stream id must be consecutively increasing by 1. So send the message then update the connection state
-     * once we've made it to the wire. */
-    continuation->stream_id = continuation->connection->latest_stream_id + 1;
+    continuation->stream_id = continuation->connection->synced_data.latest_stream_id + 1;
     AWS_LOGF_DEBUG(
         AWS_LS_EVENT_STREAM_RPC_CLIENT,
         "id=%p: continuation's new stream id is %" PRIu32,
@@ -1056,7 +1261,7 @@ int aws_event_stream_rpc_client_continuation_activate(
         continuation->stream_id);
 
     if (aws_hash_table_put(
-            &continuation->connection->continuation_table, &continuation->stream_id, continuation, NULL)) {
+            &continuation->connection->synced_data.continuation_table, &continuation->stream_id, continuation, NULL)) {
         AWS_LOGF_ERROR(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
             "id=%p: storing the new stream failed with %s",
@@ -1066,6 +1271,16 @@ int aws_event_stream_rpc_client_continuation_activate(
         goto clean_up;
     }
 
+    /*
+     * In the original event stream, this was a synchronous operation and so the stream id increment happened after
+     * flush callback.  Post-refactor, this submits an async cross-thread task to the event loop that sends the message.
+     *
+     * Cross thread tasks are handled in-order and we hold the lock while allocating and submitting the task, so we
+     * know that the send tasks will be processed in stream id order on the event loop.  The question remains, what
+     * happens if there's a failure to send; will that disrupt stream id order due to a need to rewind?  The answer is
+     * no because any failures to send after this point are connection-fatal, so it doesn't matter that the stream ids
+     * get out-of-order.
+     */
     if (s_send_protocol_message(
             continuation->connection,
             continuation,
@@ -1074,7 +1289,8 @@ int aws_event_stream_rpc_client_continuation_activate(
             continuation->stream_id,
             flush_fn,
             user_data)) {
-        aws_hash_table_remove(&continuation->connection->continuation_table, &continuation->stream_id, NULL, NULL);
+        aws_hash_table_remove(
+            &continuation->connection->synced_data.continuation_table, &continuation->stream_id, NULL, NULL);
         continuation->stream_id = 0;
         AWS_LOGF_ERROR(
             AWS_LS_EVENT_STREAM_RPC_CLIENT,
@@ -1087,7 +1303,7 @@ int aws_event_stream_rpc_client_continuation_activate(
     /* The continuation table gets a ref count on the continuation. Take it here. */
     aws_event_stream_rpc_client_continuation_acquire(continuation);
 
-    continuation->connection->latest_stream_id = continuation->stream_id;
+    continuation->connection->synced_data.latest_stream_id = continuation->stream_id;
     ret_val = AWS_OP_SUCCESS;
 
 clean_up:

--- a/source/event_stream_rpc_server.c
+++ b/source/event_stream_rpc_server.c
@@ -716,13 +716,13 @@ void aws_event_stream_rpc_server_connection_close(
     struct aws_event_stream_rpc_server_connection *connection,
     int shutdown_error_code) {
 
-    if (aws_event_stream_rpc_server_connection_is_open(connection)) {
+    size_t expect_open = 1U;
+    if (aws_atomic_compare_exchange_int(&connection->is_open, &expect_open, 0U)) {
         AWS_LOGF_DEBUG(
             AWS_LS_EVENT_STREAM_RPC_SERVER,
             "id=%p: closing connection with error %s",
             (void *)connection,
             aws_error_debug_str(shutdown_error_code));
-        aws_atomic_store_int(&connection->is_open, 0U);
         aws_channel_shutdown(connection->channel, shutdown_error_code);
 
         if (!connection->bootstrap_owned) {


### PR DESCRIPTION
Issue: send_protocol_message directly accessed the channel/handler when there was no guarantee they would still be valid.

Solution: Remove the atomics and divided internal data into event-loop-only and lock-synchronized.  Updated public APIs to use event loop tasks if they need to access the channel.  This does mean that certain API calls that would fail synchronously now fail asynchronously.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
