### PR TITLE
Serialized scheduling

### DIFF
--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -801,8 +801,8 @@ static void s_send_message_task_fn(struct aws_task *task, void *arg, enum aws_ta
             if (aws_event_stream_rpc_client_continuation_is_closed(message_args->continuation)) {
                 AWS_LOGF_INFO(
                     AWS_LS_EVENT_STREAM_RPC_CLIENT,
-                    "id=%p: cannot send, continuation is already closed",
-                    (void *)connection);
+                    "id=%p: continuation closed, cannot send messages",
+                    (void *)message_args->continuation);
 
                 failure_error_code = AWS_ERROR_EVENT_STREAM_RPC_STREAM_CLOSED;
                 goto should_fail_block;


### PR DESCRIPTION
Client protocol messages now use the new serialized scheduling API on event loops.  This prevents a race condition where stream ids could get submitted out-of-order because the normal schedule API uses short circuiting on in-event-loop submits.

Additionally:

* (Client) Move the continuation on-message callback invocation after we mark the stream as closed for messages with the terminate stream flag set
* (Client) Don't send messages on a continuation if it has been marked closed
* (Client) Only shutdown the channel if a non-continuation message fails to send.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
