### PR TITLE
Fix on big-endian

### DIFF
--- a/source/event_stream.c
+++ b/source/event_stream.c
@@ -250,9 +250,11 @@ int aws_event_stream_read_headers_from_buffer(
         AWS_RETURN_ERROR_IF(
             aws_byte_cursor_read(&buffer_cur, header.header_name, (size_t)header.header_name_len),
             AWS_ERROR_EVENT_STREAM_BUFFER_LENGTH_MISMATCH);
+        uint8_t value_type_byte;
         AWS_RETURN_ERROR_IF(
-            aws_byte_cursor_read_u8(&buffer_cur, (uint8_t *)&header.header_value_type),
+            aws_byte_cursor_read_u8(&buffer_cur, &value_type_byte),
             AWS_ERROR_EVENT_STREAM_BUFFER_LENGTH_MISMATCH);
+        header.header_value_type = value_type_byte;
 
         switch (header.header_value_type) {
             case AWS_EVENT_STREAM_HEADER_BOOL_FALSE:


### PR DESCRIPTION
Writing to the first byte of a multi-byte int value is inconsistent between endianess. Using a uint8_t value in between allows for correct results on big-endian systems as well.

Fixes 53691ffb06d9 Added hardened boundary condition checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
