### PR TITLE
Obtain the continuation token lock early

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.72
+  BUILDER_VERSION: v0.9.90
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-event-stream
@@ -159,7 +159,7 @@ jobs:
         python .\aws-c-event-stream\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-event-stream\build\aws-c-event-stream
 
   macos:
-    runs-on: macos-14 # latest
+    runs-on: macos-15 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -172,7 +172,7 @@ jobs:
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
   macos-x64:
-    runs-on: macos-14-large # latest
+    runs-on: macos-15-large # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/source/event_stream_rpc_client.c
+++ b/source/event_stream_rpc_client.c
@@ -1257,13 +1257,14 @@ int aws_event_stream_rpc_client_continuation_activate(
     AWS_LOGF_TRACE(AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: activating continuation", (void *)continuation);
     int ret_val = AWS_OP_ERR;
 
+    aws_mutex_lock(&continuation->connection->lock);
+
     if (continuation->stream_id) {
+        aws_mutex_unlock(&continuation->connection->lock);
         AWS_LOGF_ERROR(
             AWS_LS_EVENT_STREAM_RPC_CLIENT, "id=%p: stream has already been activated", (void *)continuation);
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
     }
-
-    aws_mutex_lock(&continuation->connection->lock);
 
     if (continuation->connection->synced_data.is_open &&
         continuation->connection->synced_data.handshake_state == CONNECTION_HANDSHAKE_STATE_CONNECT_ACK_PROCESSED) {


### PR DESCRIPTION
*Issue #, if available:*
The null-check for continuation's stream_id happens before the lock is obtained on the continuation's connection which can cause parallel threads to overwrite stream_ids written to the continuation thus evading the lock and sending the same data twice if stream ids are sent in order / close the connection if not. This would only happen if the customer activates the same activation twice in parallel threads almost at the same time.

*Description of changes:*
Obtain the lock before verifying that the token does not have a stream id, if it does unlock the token and return. 
If not, proceed to the rest of the critical section and assign a stream id for the token.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
