### PR TITLE
[AI] docs: note aws-lc and s2n-tls are required on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ CMake 3.9+ is required to build.
 
 `<install-path>` must be an absolute path in the following instructions.
 
-#### Linux-Only Dependencies
+#### Linux and macOS Dependencies
 
-If you are building on Linux, you will need to build aws-lc and s2n-tls first.
+If you are building on Linux or macOS, you will need to build aws-lc and s2n-tls first.
 
 ```
 git clone git@github.com:awslabs/aws-lc.git


### PR DESCRIPTION
> **Note:** This PR was generated by an AI assistant on behalf of the author.

## Summary
Update README to reflect that aws-lc and s2n-tls are required on macOS in
addition to Linux. Previously the section was titled "Linux-Only Dependencies"
and only mentioned Linux.

## Changes
- Rename "Linux-Only Dependencies" section to "Linux and macOS Dependencies"
- Update the sentence to say "Linux or macOS" instead of just "Linux"
